### PR TITLE
Added support for async calls in pages to return dynamic content

### DIFF
--- a/lib/pages/page.js
+++ b/lib/pages/page.js
@@ -19,7 +19,7 @@ module.exports = class Page {
 		this._defaultRequired = true
 	}
 
-	section(name, closure) {
+	async section(name, closure) {
 		let sec
 		let callable = closure
 		if (typeof name === 'string') {
@@ -31,7 +31,7 @@ module.exports = class Page {
 
 		this._sections.push(sec)
 		if (callable) {
-			callable(sec)
+			await callable(sec)
 		}
 
 		return this

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -228,9 +228,9 @@ module.exports = class SmartApp {
 		this._handleCallback(request.body, responders.httpResponder(response, this._log))
 	}
 
-	handleMockCallback(body) {
+	async handleMockCallback(body) {
 		const responder = responders.mockResponder(this._log)
-		this._handleCallback(body, responder)
+		await this._handleCallback(body, responder)
 		return responder.response
 	}
 
@@ -293,8 +293,9 @@ module.exports = class SmartApp {
 							const pageHandler = this._pages[pageId]
 							if (pageHandler) {
 								const page = this._localizationEnabled ? new Page(pageId, context.locale) : new Page(pageId)
-								pageHandler(context, page, configurationData)
-								responder.respond({statusCode: 200, configurationData: {page: page.toJson()}})
+								Promise.resolve(pageHandler(context, page, configurationData)).then(() => {
+									responder.respond({statusCode: 200, configurationData: {page: page.toJson()}})
+								})
 							} else {
 								throw new Error(`Page '${configurationData.pageId}' not found`)
 							}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/smartapp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/smartapp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NodeJS SDK for SmartApps",
   "displayName": "SmartThings SmartApp SDK for NodeJS",
   "author": "SmartThings",

--- a/test/smartapp-page-spec.js
+++ b/test/smartapp-page-spec.js
@@ -20,7 +20,8 @@ describe('smartapp-page-spec', () => {
 			})
 		})
 
-		const initResponse = app.handleMockCallback({
+		// Initialize configuration callback
+		app.handleMockCallback({
 			lifecycle: 'CONFIGURATION',
 			executionId: 'e6903fe6-f88f-da69-4c12-e2802606ccbc',
 			locale: 'en',
@@ -38,9 +39,19 @@ describe('smartapp-page-spec', () => {
 				config: {}
 			},
 			settings: {}
+		}).then(initResponse => {
+			const expectedInitResponse = {initialize: {
+				id: 'xxx',
+				firstPageId: 'eaMainPage',
+				permissions: [],
+				disableCustomDisplayName: false,
+				disableRemoveApp: false
+			}}
+
+			assert.deepStrictEqual(initResponse.configurationData, expectedInitResponse)
 		})
 
-		const pageResponse = app.handleMockCallback({
+		app.handleMockCallback({
 			lifecycle: 'CONFIGURATION',
 			executionId: 'abcf6e72-60f4-1f27-341b-449ad9e2192e',
 			locale: 'en',
@@ -58,68 +69,59 @@ describe('smartapp-page-spec', () => {
 				config: {}
 			},
 			settings: {}
-		})
-
-		const expectedInitResponse = {initialize: {
-			id: 'xxx',
-			firstPageId: 'eaMainPage',
-			permissions: [],
-			disableCustomDisplayName: false,
-			disableRemoveApp: false
-		}}
-
-		const expectedPageResponse = {
-			page: {
-				name: 'pages.eaMainPage.name',
-				complete: true,
-				pageId: 'eaMainPage',
-				nextPageId: null,
-				previousPageId: null,
-				sections: [
-					{
-						name: 'whenDoorOpensAndCloses',
-						settings: [
-							{
-								id: 'contactSensor',
-								name: 'pages.eaMainPage.settings.contactSensor.name',
-								required: true,
-								type: 'DEVICE',
-								description: 'Tap to set',
-								multiple: false,
-								capabilities: [
-									'contactSensor'
-								],
-								permissions: [
-									'r'
-								]
-							}
-						]
-					},
-					{
-						name: 'turnLightsOnAndOff',
-						settings: [
-							{
-								id: 'lights',
-								name: 'pages.eaMainPage.settings.lights.name',
-								required: true,
-								type: 'DEVICE',
-								description: 'Tap to set',
-								multiple: true,
-								capabilities: [
-									'switch'
-								],
-								permissions: [
-									'r',
-									'x'
-								]
-							}
-						]
-					}
-				]
+		}).then(pageResponse => {
+			const expectedPageResponse = {
+				page: {
+					name: 'pages.eaMainPage.name',
+					complete: true,
+					pageId: 'eaMainPage',
+					nextPageId: null,
+					previousPageId: null,
+					sections: [
+						{
+							name: 'whenDoorOpensAndCloses',
+							settings: [
+								{
+									id: 'contactSensor',
+									name: 'pages.eaMainPage.settings.contactSensor.name',
+									required: true,
+									type: 'DEVICE',
+									description: 'Tap to set',
+									multiple: false,
+									capabilities: [
+										'contactSensor'
+									],
+									permissions: [
+										'r'
+									]
+								}
+							]
+						},
+						{
+							name: 'turnLightsOnAndOff',
+							settings: [
+								{
+									id: 'lights',
+									name: 'pages.eaMainPage.settings.lights.name',
+									required: true,
+									type: 'DEVICE',
+									description: 'Tap to set',
+									multiple: true,
+									capabilities: [
+										'switch'
+									],
+									permissions: [
+										'r',
+										'x'
+									]
+								}
+							]
+						}
+					]
+				}
 			}
-		}
-		assert.deepStrictEqual(initResponse.configurationData, expectedInitResponse)
-		assert.deepStrictEqual(pageResponse.configurationData, expectedPageResponse)
+			assert.deepStrictEqual(pageResponse.configurationData, expectedPageResponse)
+		})
 	})
 
 	it('should configure event logger', () => {


### PR DESCRIPTION
Change to allow configuration pages to include async function calls so that page content can be dynamically generated from calls to databases or other external data sources.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
