### PR TITLE
Add jsdocs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+          "type": "node",
+          "request": "launch",
+          "name": "Mocha All",
+          "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+          "args": [
+              "--timeout",
+              "999999",
+              "--colors",
+              "${workspaceFolder}/test"
+          ],
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen"
+      },
+      {
+          "type": "node",
+          "request": "launch",
+          "name": "Mocha Current File",
+          "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+          "args": [
+              "--timeout",
+              "999999",
+              "--colors",
+              "${file}"
+          ],
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen"
+      }
+    ]
+  }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-'use strict'
-
-const SmartApp = require('./lib/smart-app')
-
-module.exports = (function (options = {}) {
-	return new SmartApp(options)
-})()
-
-module.exports.default = Object.assign({}, module.exports)

--- a/lib/api.js
+++ b/lib/api.js
@@ -13,17 +13,41 @@ const Subscriptions = require('./platform/subscriptions')
 
 module.exports = class SmartThingsApi {
 	constructor(options) {
+		// TODO – expand these JSdocs
+		/** @type { import('./platform/client') } */
 		this.client = new Client(options)
+
+		/** @type { import('./platform/apps') } */
 		this.apps = new Apps(this)
+
+		/** @type { import('./platform/deviceprofiles') } */
 		this.deviceProfiles = new DeviceProfiles(this)
+
+		/** @type { import('./platform/devices') } */
 		this.devices = new Devices(this)
+
+		/** @type { import('./platform/installedapps') } */
 		this.installedApps = new InstalledApps(this)
+
+		/** @type { import('./platform/locations') } */
 		this.locations = new Locations(this)
+
+		/** @type { import('./platform/modes') } */
 		this.modes = new Modes(this)
+
+		/** @type { import('./platform/scenes') } */
 		this.scenes = new Scenes(this)
+
+		/** @type { import('./platform/schedules') } */
 		this.schedules = new Schedules(this)
+
+		/** @type { import('./platform/subscriptions') } */
 		this.subscriptions = new Subscriptions(this)
+
+		/** @type {String} */
 		this.installedAppId = options.installedAppId
+
+		/** @type {String} */
 		this.locationId = options.locationId
 	}
 }

--- a/lib/pages/boolean-setting.js
+++ b/lib/pages/boolean-setting.js
@@ -8,11 +8,24 @@ module.exports = class BooleanSetting extends SectionSetting {
 		this._type = 'BOOLEAN'
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {BooleanSetting} Boolean Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 
+	/**
+	 * Indicates if this input should refresh configs after a change in value.
+	 *
+	 * @param {String} value
+	 * @default false
+	 * @returns {BooleanSetting} Boolean Setting instance
+	 */
 	submitOnChange(value) {
 		this._submitOnChange = value
 		return this

--- a/lib/pages/color-setting.js
+++ b/lib/pages/color-setting.js
@@ -2,17 +2,17 @@
 
 const SectionSetting = require('./section-setting.js')
 
-module.exports = class ImageSetting extends SectionSetting {
+module.exports = class ColorSetting extends SectionSetting {
 	constructor(section, id) {
 		super(section, id)
-		this._type = 'IMAGE'
+		this._type = 'COLOR'
 	}
 
 	/**
 	 * Configure your image source
 	 *
 	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
-	 * @returns {ImageSetting} Image Setting instance
+	 * @returns {ColorSetting} Color Setting instance
 	 */
 	image(source) {
 		this._image = source

--- a/lib/pages/decimal-setting.js
+++ b/lib/pages/decimal-setting.js
@@ -9,21 +9,45 @@ module.exports = class DecimalSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
+	/**
+	 * The maximum inclusive value the decimal can be set to.
+	 *
+	 * @param {number} value Maximum value
+	 * @returns {DecimalSetting} Decimal Setting instance
+	 */
 	max(value) {
 		this._max = value
 		return this
 	}
 
+	/**
+	 * The minimum inclusive value the decimal can be set to.
+	 *
+	 * @param {number} value Minimum value
+	 * @returns {DecimalSetting} Decimal Setting instance
+	 */
 	min(value) {
 		this._min = value
 		return this
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {DecimalSetting} Decimal Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 
+	/**
+	 * A string to be shown after the text input field.
+	 *
+	 * @param {String} value Max length 10 characters
+	 * @returns {DecimalSetting} Decimal Setting instance
+	 */
 	postMessage(value) {
 		this._postMessage = value
 		return this

--- a/lib/pages/device-setting.js
+++ b/lib/pages/device-setting.js
@@ -10,49 +10,120 @@ module.exports = class DeviceSetting extends SectionSetting {
 		this._multiple = false
 	}
 
+	/**
+	 * Indicates if this device setting can have multiple values.
+	 *
+	 * @param {Boolean} multiple
+	 * @default false
+	 * @returns {DeviceSetting} Device Setting instance
+	 */
 	multiple(value) {
 		this._multiple = value
 		return this
 	}
 
+	/**
+	 * Indicates if this input should close on selection.
+	 *
+	 * @param {Boolean} value
+	 * @default true
+	 * @returns {DeviceSetting} Device Setting instance
+	 */
 	closeOnSelection(value) {
 		this._closeOnSelection = value
 		return this
 	}
 
+	/**
+	 * Indicates if this input should refresh configs after a change in value.
+	 *
+	 * @param {Boolean} value
+	 * @default true
+	 * @returns {DeviceSetting} Device Setting instance
+	 */
 	submitOnChange(value) {
 		this._submitOnChange = value
 		return this
 	}
 
+	/**
+	 * Indicates if the first device in the list of options should be pre selected.
+	 *
+	 * @param {Boolean} value
+	 * @default true
+	 * @returns {DeviceSetting} Device Setting instance
+	 */
 	preselect(value) {
 		this._preselect = value
 		return this
 	}
 
-	capabilities(value) {
-		this._capabilities = value
+	/**
+	 * An array of required capabilities for the device(s) options.
+	 *
+	 * @param {Array.<String>} items Each string has a max length of 128 characters
+	 * @returns {DeviceSetting} Device Setting instance
+	 */
+	capabilities(items) {
+		this._capabilities = items
 		return this
 	}
 
-	capability(value) {
-		this._capabilities = [value]
+	/**
+	 * Set a singular required capabilities for the device(s) options.
+	 *
+	 * @param {String} capability Capability string has a max length of 128 characters
+	 * @returns {DeviceSetting} Device Setting instance
+	 */
+	capability(capability) {
+		this._capabilities = [capability]
 		return this
 	}
 
-	excludeCapabilities(value) {
-		this._excludeCapabilities = value
+	/**
+	 * The excluded capabilities for the device(s) options.
+	 *
+	 * @param {Array.<String>} items Each string has a max length of 128 characters
+	 * @returns {DeviceSetting} Device Setting instance
+	 */
+	excludeCapabilities(capabilities) {
+		this._excludeCapabilities = typeof capabilities === 'string' ?
+			capabilities.split(' ') :
+			capabilities
 		return this
 	}
 
-	// TODO -- need to be able to OR capabilities
+	/**
+	 * Set a singular excluded capability for the device(s) options.
+	 *
+	 * @param {String} value Capability string has a max length of 128 characters
+	 * @returns {DeviceSetting} Device Setting instance
+	 */
 	excludeCapability(value) {
+		// TODO -- need to be able to OR capabilities
 		this._excludeCapabilities = [value]
 		return this
 	}
 
-	permissions(value) {
-		this._permissions = typeof value === 'string' ? value.split('') : value
+	/**
+	 * The required permissions for the selected device(s).
+	 *
+	 * @param {Array.<String> | String} permissions Accepts a single string permission or an array
+	 * @returns {DeviceSetting} Device Setting instance
+	 * @example
+	 * // Separated with no delimiter
+	 * section.deviceSetting().permissions('rwx')
+	 *
+	 * @example
+	 * // Separated with space delimiter
+	 * section.deviceSetting().permissions('r w x')
+	 *
+	 * @example
+	 * // Separated into an array
+	 * section.deviceSetting().permissions(['r', 'w', 'x'])
+	 */
+	permissions(permissions) {
+		this._permissions = typeof permissions === 'string' ? permissions.match(/[rwx]/ig) : permissions
 		return this
 	}
 

--- a/lib/pages/email-setting.js
+++ b/lib/pages/email-setting.js
@@ -9,9 +9,14 @@ module.exports = class EmailSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
-	// TODO -- Is this right? It is from Swagger
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {EmailSetting} Email Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 

--- a/lib/pages/enum-setting.js
+++ b/lib/pages/enum-setting.js
@@ -9,25 +9,96 @@ module.exports = class EnumSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
+	/**
+	 * @typedef GroupedOption
+	 * @prop {String} name The display name of this group of enum options. Max length 128 characters.
+	 * @prop {Array.<Option>} options The enum options.
+	 */
+
+	/**
+	 * @typedef Option
+	 * @prop {String} id The unique ID for this option. Max length 128 characters.
+	 * @prop {String} name The display name for this option. Max length 128 characters.
+	 */
+
+	/**
+	 * Indicates if this enum setting can have multiple values.
+	 *
+	 * @param {Boolean} value Multiple values
+	 * @default false
+	 * @returns {EnumSetting} Enum Setting instance
+	 */
 	multiple(value) {
 		this._multiple = value
 		return this
 	}
 
+	/**
+	 * Indicates if this input should close on selection.
+	 *
+	 * @param {Boolean} value Close on selection value
+	 * @default true
+	 * @returns {EnumSetting} Enum Setting instance
+	 */
 	closeOnSelection(value) {
 		this._closeOnSelection = value
 		return this
 	}
 
-	groupedOptions(value) {
-		this._groupedOptions = value
+	/**
+	 * Display the enum options as named groups.
+	 *
+	 * @param {Array.<GroupedOption>} groups Array of grouped options
+	 * @returns {EnumSetting} Enum Setting instance
+	 *
+	 * @example
+	 ```javascript
+const groups = [{
+        name: 'First Group',
+        options: [{
+            id: 'option-001',
+            name: 'Option 1'
+        }]
+    },
+    {
+        name: 'Second Group',
+        options: [{
+            id: 'option-002',
+            name: 'Option 2'
+        }]
+    }
+]
+section.enumSetting('id').groupedOptions(groups)
+	 ```
+	 */
+	groupedOptions(groups) {
+		this._groupedOptions = groups
 		return this
 	}
 
-	options(value) {
+	/**
+	 * The enum options.
+	 *
+	 * @param {Option | Array.<Option>} options Single or array of options
+	 * @returns {EnumSetting} Enum Setting instance
+	 * @example
+	 ```javascript
+const options = [{
+        id: 'option-001',
+        name: 'Option 1'
+    },
+    {
+        id: 'option-002',
+        name: 'Option 2'
+    }
+]
+section.enumSetting('id').options(options)
+	 ```
+	 */
+	options(options) {
 		const values = []
-		if (Array.isArray(value)) {
-			for (const it of value) {
+		if (Array.isArray(options)) {
+			for (const it of options) {
 				if (it instanceof Object) {
 					values.push(it)
 				} else {
@@ -35,25 +106,38 @@ module.exports = class EnumSetting extends SectionSetting {
 					values.push({id: item, name: item})
 				}
 			}
-		} else if (value instanceof Object) {
-			for (const property in value) {
-				if (Object.prototype.hasOwnProperty.call(value, property)) {
-					values.push({id: property, name: value[property]})
+		} else if (options instanceof Object) {
+			for (const property in options) {
+				if (Object.prototype.hasOwnProperty.call(options, property)) {
+					values.push({id: property, name: options[property]})
 				}
 			}
 		} else {
-			throw new TypeError(`${typeof value} not valid for options`)
+			throw new TypeError(`${typeof options} not valid for options`)
 		}
 
 		this._options = values
 		return this
 	}
 
+	/**
+	 * Indicates if this input should refresh configs after a change in value.
+	 *
+	 * @param {Boolean} value Submit on change value
+	 * @default false
+	 * @returns {EnumSetting} Enum Setting instance
+	 */
 	submitOnChange(value) {
 		this._submitOnChange = value
 		return this
 	}
 
+	/**
+	 * Style of the setting.
+	 *
+	 * @param {('COMPLETE','ERROR','DEFAULT','DROPDOWN')} value
+	 * @returns {EnumSetting} Enum Setting instance
+	 */
 	style(value) {
 		this._style = value
 		return this

--- a/lib/pages/images-setting.js
+++ b/lib/pages/images-setting.js
@@ -8,8 +8,14 @@ module.exports = class ImagesSetting extends SectionSetting {
 		this._type = 'IMAGES'
 	}
 
-	images(value) {
-		this._images = value
+	/**
+	 * Configure your image array sources
+	 *
+	 * @param {Array.<String>} sources The images to display. HTTPS urls. Max length 2048 characters.
+	 * @returns {ImagesSetting} ImagesSetting instance
+	 */
+	images(sources) {
+		this._images = sources
 		return this
 	}
 

--- a/lib/pages/link-setting.js
+++ b/lib/pages/link-setting.js
@@ -8,16 +8,34 @@ module.exports = class LinkSetting extends SectionSetting {
 		this._type = 'LINK'
 	}
 
+	/**
+	 * The page to navigate to.
+	 *
+	 * @param {String} source Max length 2048 characters.
+	 * @returns {LinkSetting} Link Setting instance
+	 */
 	url(value) {
 		this._url = value
 		return this
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {LinkSetting} Link Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 
+	/**
+	 * Style of the setting
+	 *
+	 * @param {('COMPLETE', 'ERROR', 'DEFAULT', 'BUTTON')} value
+	 * @returns {LinkSetting} Link Setting instance
+	 */
 	style(value) {
 		this._style = value
 		return this

--- a/lib/pages/message-group-setting.js
+++ b/lib/pages/message-group-setting.js
@@ -2,24 +2,31 @@
 
 const SectionSetting = require('./section-setting.js')
 
-module.exports = class SecuritySetting extends SectionSetting {
+module.exports = class MessageGroupSetting extends SectionSetting {
 	constructor(section, id) {
 		super(section, id)
-		this._type = 'ENUM'
+		this._type = 'MESSAGE_GROUP'
 		this._description = 'Tap to set'
-		this._options = [
-			{id: 'DISARMED', name: 'Disarmed'},
-			{id: 'ARMED_STAY', name: 'Armed/Stay'},
-			{id: 'ARMED_AWAY', name: 'Armed/Away'}
-		]
+		this._messageGroupKey = ''
 	}
 
 	/**
-	 * Indicates if this security setting can have multiple values.
+	 * The key value of the message group.
+	 *
+	 * @param {String} key
+	 * @returns {MessageGroupSetting} Message Group Setting instance
+	 */
+	messageGroupKey(key) {
+		this._messageGroupKey = key
+		return this
+	}
+
+	/**
+	 * Indicates if this message group setting can have multiple values.
 	 *
 	 * @param {Boolean} value
 	 * @default false
-	 * @returns {SecuritySetting} Security Setting instance
+	 * @returns {MessageGroupSetting} Message Group Setting instance
 	 */
 	multiple(value) {
 		this._multiple = value
@@ -31,7 +38,7 @@ module.exports = class SecuritySetting extends SectionSetting {
 	 *
 	 * @param {Boolean} value
 	 * @default true
-	 * @returns {SecuritySetting} Security Setting instance
+	 * @returns {MessageGroupSetting} Message Group Setting instance
 	 */
 	closeOnSelection(value) {
 		this._closeOnSelection = value
@@ -42,7 +49,8 @@ module.exports = class SecuritySetting extends SectionSetting {
 	 * Indicates if this input should refresh configs after a change in value.
 	 *
 	 * @param {Boolean} value
-	 * @returns {SecuritySetting} Security Setting instance
+	 * @default false
+	 * @returns {MessageGroupSetting} Message Group Setting instance
 	 */
 	submitOnChange(value) {
 		this._submitOnChange = value
@@ -53,7 +61,7 @@ module.exports = class SecuritySetting extends SectionSetting {
 	 * Style of the setting.
 	 *
 	 * @param {('COMPLETE','ERROR','DEFAULT','DROPDOWN')} value
-	 * @returns {SecuritySetting} Security Setting instance
+	 * @returns {EnumSetting} Enum Setting instance
 	 */
 	style(value) {
 		this._style = value
@@ -68,6 +76,10 @@ module.exports = class SecuritySetting extends SectionSetting {
 
 		if (this._closeOnSelection) {
 			result.closeOnSelection = this._closeOnSelection
+		}
+
+		if (this._groupedOptions) {
+			result.groupedOptions = this._groupedOptions
 		}
 
 		if (this._options) {

--- a/lib/pages/mode-setting.js
+++ b/lib/pages/mode-setting.js
@@ -9,21 +9,48 @@ module.exports = class ModeSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
+	/**
+	 * Indicates if this mode setting can have multiple values.
+	 *
+	 * @param {Boolean} value
+	 * @default false
+	 * @returns {ModeSetting} Mode Setting instance
+	 */
 	multiple(value) {
 		this._multiple = value
 		return this
 	}
 
+	/**
+	 * Indicates if this input should close on selection.
+	 *
+	 * @param {Boolean} value
+	 * @default true
+	 * @returns {ModeSetting} Mode Setting instance
+	 */
 	closeOnSelection(value) {
 		this._closeOnSelection = value
 		return this
 	}
 
+	/**
+	 * Indicates if this input should refresh configs after a change in value.
+	 *
+	 * @param {Boolean} value
+	 * @default false
+	 * @returns {ModeSetting} Mode Setting instance
+	 */
 	submitOnChange(value) {
 		this._submitOnChange = value
 		return this
 	}
 
+	/**
+	 * Style of the setting.
+	 *
+	 * @param {('COMPLETE', 'ERROR', 'DEFAULT')} value
+	 * @returns {ModeSetting} Mode Setting instance
+	 */
 	style(value) {
 		this._style = value
 		return this

--- a/lib/pages/number-setting.js
+++ b/lib/pages/number-setting.js
@@ -9,31 +9,69 @@ module.exports = class NumberSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
+	/**
+	 * The maximum inclusive value the number can be set to.
+	 *
+	 * @param {number} value Maximum value
+	 * @returns {NumberSetting} Number Setting instance
+	 */
 	max(value) {
 		this._max = value
 		return this
 	}
 
+	/**
+	 * The minimum inclusive value the number can be set to.
+	 *
+	 * @param {number} value Minimum value
+	 * @returns {NumberSetting} Number Setting instance
+	 */
 	min(value) {
 		this._min = value
 		return this
 	}
 
+	/**
+	 * The increment to step by.
+	 *
+	 * @param {number} value Increment value
+	 * @default 1
+	 * @returns {NumberSetting} Number Setting instance
+	 */
 	step(value) {
 		this._step = value
 		return this
 	}
 
+	/**
+	 * The way to style the number input.
+	 *
+	 * @param {String} value Style value
+	 * @default 'SLIDER'
+	 * @returns {NumberSetting} Number Setting instance
+	 */
 	style(value) {
 		this._style = value
 		return this
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {NumberSetting} Number Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 
+	/**
+	 * A string to be shown after the text input field.
+	 *
+	 * @param {String} value Max length 10 characters
+	 * @returns {NumberSetting} Number Setting instance
+	 */
 	postMessage(value) {
 		this._postMessage = value
 		return this

--- a/lib/pages/oauth-setting.js
+++ b/lib/pages/oauth-setting.js
@@ -8,13 +8,30 @@ module.exports = class OAuthSetting extends SectionSetting {
 		this._type = 'OAUTH'
 	}
 
-	urlTemplate(value) {
-		this._urlTemplate = value
+	/**
+	 * The url to use for the OAuth service. Use __SmartThingsOAuthCallback__
+	 * in the template for the callback/redirect url you need to provide
+	 * to the OAuth service.
+	 *
+	 * @param {*} url Max length 2048 characters
+	 * @returns {OAuthSetting} OAuth Setting instance
+	 * @example
+	 * var url = 'https://api.smartthings.com/oauth/callback?param1=1&param2=2&callback=__SmartThingsOAuthCallback__'
+	 * section.oauthSetting('id').url(url)
+	 */
+	urlTemplate(url) {
+		this._urlTemplate = url
 		return this
 	}
 
-	style(value) {
-		this._style = value
+	/**
+	 * Style of the setting
+	 *
+	 * @param {('COMPLETE','ERROR','DEFAULT')} style
+	 * @returns {OAuthSetting} OAuth Setting instance
+	 */
+	style(style) {
+		this._style = style
 		return this
 	}
 

--- a/lib/pages/page-setting.js
+++ b/lib/pages/page-setting.js
@@ -9,16 +9,34 @@ module.exports = class ParagraphSetting extends SectionSetting {
 		this._page = id
 	}
 
-	page(value) {
-		this._page = value
+	/**
+	 * The page to navigate to.
+	 *
+	 * @param {String} id Page id. Max length 10 characters.
+	 * @returns {PageSetting} Page Setting instance
+	 */
+	page(id) {
+		this._page = id
 		return this
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {PageSetting} Page Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 
+	/**
+	 * Style of the setting
+	 *
+	 * @param {('COMPLETE', 'ERROR', 'DEFAULT', 'BUTTON')} value
+	 * @returns {PageSetting} Page Setting instance
+	 */
 	style(value) {
 		this._style = value
 		return this

--- a/lib/pages/page.js
+++ b/lib/pages/page.js
@@ -16,9 +16,22 @@ module.exports = class Page {
 		}
 
 		this._settingIds = []
-		this._defaultRequired = false
+		this._defaultRequired = true
 	}
 
+	/**
+	 * @callback SectionCallback
+	 * @param section { import("./section") } Chainable section instance
+	 */
+
+	/**
+	 * Define sections for user defined settings. Chain as many as needed.
+	 *
+	 * https://smartthings.developer.samsung.com/docs/how-to/design-pages-smartapp.html#Page-Components
+	 * @param {String} name Name your section for use in i18n localization keys
+	 * @param {SectionCallback} closure { import("./section") } Chainable section instance
+	 * @returns {Page} Page instance
+	 */
 	async section(name, closure) {
 		let sec
 		let callable = closure
@@ -37,40 +50,79 @@ module.exports = class Page {
 		return this
 	}
 
-	complete(value) {
-		this._complete = value
+	/**
+	 * Indicates if this is the last page in the configuration process. If left unset,
+	 * `complete` will equal `true` when **no next page** and **no previous pages**
+	 * are defined.
+	 *
+	 * @param {Boolean} complete Set to true to signify that this page will complete configuration
+	 * @returns {Page} Page instance
+	 */
+	complete(complete) {
+		this._complete = complete
 		return this
 	}
 
-	name(value) {
-		this._name = value
+	/**
+	 * Name of the page to be configured.
+	 *
+	 * @param {String} name
+	 * @returns {Page} Page instance
+	 */
+	name(name) {
+		this._name = name
 		return this
 	}
 
-	style(value) {
-		this._style = value
+	/**
+	 * Change how the page is presented.
+	 *
+	 * @param {('NORMAL'|'SPLASH')} style Page style
+	 * @returns {Page} Page instance
+	 */
+	style(style) {
+		this._style = style
 		return this
 	}
 
-	nextText(value) {
-		this._nextText = value
+	/**
+	 * The text for the next button. Only applies if style is `SPLASH`.
+	 *
+	 * @param {String} text
+	 */
+	nextText(text) {
+		this._nextText = text
 		return this
 	}
 
-	nextPageId(value) {
-		this._nextPageId = value
+	/**
+	 * A developer defined page ID for the next page in the configuration process. Must be URL safe characters.
+	 *
+	 * @param {String} id
+	 * @returns {Page} Page instance
+	 */
+	nextPageId(id) {
+		this._nextPageId = id
 		return this
 	}
 
-	previousPageId(value) {
-		this._previousPageId = value
+	/**
+	 * A developer defined page ID for the previous page in the configuration process. Must be URL safe characters.
+	 *
+	 * @param {String} id
+	 * @returns {Page} Page instance
+	 */
+	previousPageId(id) {
+		this._previousPageId = id
 		return this
 	}
 
 	/**
 	 * Automatically applies the `required: true` field to all section settings
-	 * @param {Boolean} value defaults to false
-	 * @returns {Page} instance of Page
+	 *
+	 * @param {Boolean} value
+	 * @default false
+	 * @returns {Page} Page instance
 	 */
 	defaultRequired(value) {
 		this._defaultRequired = value

--- a/lib/pages/paragraph-setting.js
+++ b/lib/pages/paragraph-setting.js
@@ -18,8 +18,14 @@ module.exports = class ParagraphSetting extends SectionSetting {
 		return this
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {ParagraphSetting} Paragraph Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 

--- a/lib/pages/password-setting.js
+++ b/lib/pages/password-setting.js
@@ -9,18 +9,36 @@ module.exports = class PasswordSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
+	/**
+	 * The maximum length the password can have.
+	 *
+	 * @param {number} value
+	 * @returns {PasswordSetting} Password Setting instance
+	 */
 	maxLength(value) {
 		this._maxLength = value
 		return this
 	}
 
+	/**
+	 * The minimum length the password can have.
+	 *
+	 * @param {number} value
+	 * @returns {PasswordSetting} Password Setting instance
+	 */
 	minLength(value) {
 		this._minLength = value
 		return this
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {PasswordSetting} Password Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 

--- a/lib/pages/phone-setting.js
+++ b/lib/pages/phone-setting.js
@@ -9,8 +9,14 @@ module.exports = class PhoneSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {PhoneSetting} Phone Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 

--- a/lib/pages/scene-setting.js
+++ b/lib/pages/scene-setting.js
@@ -9,21 +9,48 @@ module.exports = class SceneSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
+	/**
+	 * Indicates if this scene setting can have multiple values.
+	 *
+	 * @param {Boolean} value Boolean value
+	 * @default false
+	 * @returns {SceneSetting} Scene Setting instance
+	 */
 	multiple(value) {
 		this._multiple = value
 		return this
 	}
 
+	/**
+	 * Indicates if this input should close on selection.
+	 *
+	 * @param {Boolean} value Boolean value
+	 * @default true
+	 * @returns {SceneSetting} Scene Setting instance
+	 */
 	closeOnSelection(value) {
 		this._closeOnSelection = value
 		return this
 	}
 
+	/**
+	 * Indicates if this input should refresh configs after a change in value.
+	 *
+	 * @param {Boolean} value Boolean value
+	 * @default false
+	 * @returns {SceneSetting} Scene Setting instance
+	 */
 	submitOnChange(value) {
 		this._submitOnChange = value
 		return this
 	}
 
+	/**
+	 * Style of the setting.
+	 *
+	 * @param {('COMPLETE','ERROR','DEFAULT','DROPDOWN')} value
+	 * @returns {SceneSetting} Scene Setting instance
+	 */
 	style(value) {
 		this._style = value
 		return this

--- a/lib/pages/section-setting.js
+++ b/lib/pages/section-setting.js
@@ -5,11 +5,11 @@ module.exports = class SectionSetting {
 		this._section = section
 		this._id = id
 		this._name = this.i18nKey('name')
-		this._description = ''
+		this._description = this.i18nKey('description')
 		this._required = section._defaultRequired
 		if (section._page._settingIds.includes(id)) {
 			throw new Error(`Setting ID '${id}' has already been used.`)
-		} else {
+		} else if (id) {
 			section._page._settingIds.push(id)
 		}
 	}
@@ -44,6 +44,11 @@ module.exports = class SectionSetting {
 		return this
 	}
 
+	submitOnChange(value) {
+		this._submitOnChange = value
+		return this
+	}
+
 	i18nKey(property) {
 		return this._section._page.i18nKey(`settings.${this._id}.${property}`)
 	}
@@ -55,16 +60,19 @@ module.exports = class SectionSetting {
 	toJson() {
 		const result = {
 			id: this._id,
-			name: this.translate(this._name),
 			required: this._required,
 			type: this._type
 		}
 
-		if (!this._description) {
-			result.description = ''
-		} else if (this._description instanceof Function) {
+		if (this._name instanceof Function) {
+			result.name = this._name()
+		} else if (typeof (this._name) === 'string' || this._name instanceof String) {
+			result.name = this.translate(this._name)
+		}
+
+		if (this._description instanceof Function) {
 			result.description = this._description()
-		} else {
+		} else if (typeof (this._name) === 'string' || this._description instanceof String) {
 			result.description = this.translate(this._description)
 		}
 
@@ -74,6 +82,10 @@ module.exports = class SectionSetting {
 
 		if (this._disabled) {
 			result.disabled = this._disabled
+		}
+
+		if (this._submitOnChange) {
+			result.submitOnChange = this._submitOnChange
 		}
 
 		return result

--- a/lib/pages/section.js
+++ b/lib/pages/section.js
@@ -16,11 +16,13 @@ const PageSetting = require('./page-setting')
 const ImageSetting = require('./image-setting')
 const ImagesSetting = require('./images-setting')
 const VideoSetting = require('./video-setting')
+const ColorSetting = require('./color-setting')
 const EnumSetting = require('./enum-setting')
 const SoundSetting = require('./sound-setting')
 const SecuritySetting = require('./security-setting')
 const ModeSetting = require('./mode-setting')
 const SceneSetting = require('./scene-setting')
+const MessageGroupSetting = require('./message-group-setting')
 
 module.exports = class Section {
 	constructor(page, name) {
@@ -30,144 +32,338 @@ module.exports = class Section {
 		this._defaultRequired = page._defaultRequired
 	}
 
+	/**
+	 * Device Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./device-setting') } Device Setting instance
+	 */
 	deviceSetting(id) {
 		const result = new DeviceSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * OAuth Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./oauth-setting') } OAuth Setting instance
+	 */
 	oauthSetting(id) {
 		const result = new OAuthSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Time Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./time-setting') } Time Setting instance
+	 */
 	timeSetting(id) {
 		const result = new TimeSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Text Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./text-setting') } Text Setting instance
+	 */
 	textSetting(id) {
 		const result = new TextSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Password Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./password-setting') } Password Setting instance
+	 */
 	passwordSetting(id) {
 		const result = new PasswordSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Phone Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./phone-setting') } Phone Setting instance
+	 */
 	phoneSetting(id) {
 		const result = new PhoneSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Email Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./email-setting') } Email Setting instance
+	 */
 	emailSetting(id) {
 		const result = new EmailSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Number Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./number-setting') } Number Setting instance
+	 */
 	numberSetting(id) {
 		const result = new NumberSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Decimal Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./decimal-setting') } Decimal Setting instance
+	 */
 	decimalSetting(id) {
 		const result = new DecimalSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Boolean Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./boolean-setting') } Boolean Setting instance
+	 */
 	booleanSetting(id) {
 		const result = new BooleanSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Paragraph Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./paragraph-setting') } Paragraph Setting instance
+	 */
 	paragraphSetting(id) {
 		const result = new ParagraphSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Link Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./link-setting') } Link Setting instance
+	 */
 	linkSetting(id) {
 		const result = new LinkSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Page Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./page-setting') } Page Setting instance
+	 */
 	pageSetting(id) {
 		const result = new PageSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Image Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./image-setting') } Image Setting instance
+	 */
 	imageSetting(id) {
 		const result = new ImageSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Images Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./images-setting') } Images Setting instance
+	 */
 	imagesSetting(id) {
 		const result = new ImagesSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Video Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./video-setting') } Video Setting instance
+	 */
 	videoSetting(id) {
 		const result = new VideoSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Color Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./color-setting') } Color Setting instance
+	 */
+	colorSetting(id) {
+		const result = new ColorSetting(this, id)
+		this._settings.push(result)
+		return result
+	}
+
+	/**
+	 * Enum Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./enum-setting') } Enum Setting instance
+	 */
 	enumSetting(id) {
 		const result = new EnumSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Security Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./security-setting') } Security Setting instance
+	 */
 	securitySetting(id) {
 		const result = new SecuritySetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Sound Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./sound-setting') } Sound Setting instance
+	 */
 	soundSetting(id) {
 		const result = new SoundSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Mode Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./mode-setting') } Mode Setting instance
+	 */
 	modeSetting(id) {
 		const result = new ModeSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Scene Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./scene-setting') } Scene Setting instance
+	 */
 	sceneSetting(id) {
 		const result = new SceneSetting(this, id)
 		this._settings.push(result)
 		return result
 	}
 
+	/**
+	 * Message Group Setting
+	 *
+	 * @param {String} id Identifier used for i18n localization key
+	 * @returns { import('./message-group-setting') } Message Group Setting instance
+	 */
+	messageGroupSetting(id) {
+		const result = new MessageGroupSetting(this, id)
+		this._settings.push(result)
+		return result
+	}
+
+	/**
+	 * Name of the section.
+	 *
+	 * @param {String} value Max length 128 characters.
+	 * @returns {Section} Section instance
+	 */
+	name(value) {
+		this._name = value
+		return this
+	}
+
+	/**
+	 * Whether or not the section can be collapsed.
+	 *
+	 * @param {Boolean} hideable
+	 * @default false
+	 * @returns {Section} Section instance
+	 */
 	hideable(value) {
 		this._hideable = value
 		return this
 	}
 
+	/**
+	 * If section can be collapsed, whether or not it defaults to hidden.
+	 *
+	 * @param {Boolean} value
+	 * @default false
+	 * @returns {Section} Section instance
+	 */
 	hidden(value) {
 		this._hidden = value
 		return this
 	}
 
-	defaultRequired(value) {
-		this._defaultRequired = value
+	/**
+	 * Automatically applies the `required: true` field to all section settings
+	 *
+	 * @param {Boolean} defaultRequired
+	 * @default false
+	 * @returns {Page} Section instance
+	 */
+	defaultRequired(defaultRequired) {
+		this._defaultRequired = defaultRequired
+		return this
+	}
+
+	/**
+	 * Change how the section is presented
+	 *
+	 * @param {('NORMAL'|'FOOTER')} style Section style
+	 * @default "NORMAL"
+	 * @returns {Section} Section instance
+	 */
+	style(style) {
+		this._style = style
 		return this
 	}
 
@@ -181,8 +377,27 @@ module.exports = class Section {
 
 	toJson() {
 		const result = {}
-		if (this._name) {
+
+		// If (this._name instanceof Function) {
+		// 	result.name = this._name()
+		// }
+		if (typeof (this._name) === 'string' || this._name instanceof String) {
 			result.name = this._page.headers ? this.translate(this.i18nKey('name', this._name)) : this._name
+		}
+		// If (this._name) {
+		// 	result.name = this._page.headers ? this.translate(this.i18nKey('name', this._name)) : this._name
+		// }
+
+		if (this._hideable) {
+			result.hideable = this._hideable
+		}
+
+		if (this._hidden) {
+			result.hidden = this._hidden
+		}
+
+		if (this._style) {
+			result.style = this._style
 		}
 
 		result.settings = []

--- a/lib/pages/sound-setting.js
+++ b/lib/pages/sound-setting.js
@@ -8,26 +8,109 @@ module.exports = class SoundSetting extends SectionSetting {
 		this._type = 'SOUND'
 	}
 
+	/**
+	 * @typedef GroupedSoundOption
+	 * @prop {String} name The display name of this group of sound options.  Max length 128 characters.
+	 * @prop {Array.<SoundOption>} options The sound enum options.
+	 */
+
+	/**
+	 * @typedef SoundOption
+	 * @prop {String} id The unique ID for this option. Max length 128 characters.
+	 * @prop {String} name The display name for this option. Max length 128 characters.
+	 * @prop {String} sound The sound url. Either .mp3 or .wav. Max length 2048 characters.
+	 */
+
+	/**
+	 * Indicates if this enum setting can have multiple values.
+	 *
+	 * @param {Boolean} value Multiple value
+	 * @default false
+	 * @returns {SoundSetting} Sound Setting instance
+	 */
 	multiple(value) {
 		this._multiple = value
 		return this
 	}
 
-	groupedOptions(value) {
-		this._groupedOptions = value
+	/**
+	 * Display the enum options as groups.
+	 *
+	 * @param {Array.<GroupedSoundOption>} groups Array of grouped sound options
+	 * @returns {SoundSetting} Sound Setting instance
+	 *
+	 * @example
+	 ```javascript
+const groups = [{
+        name: 'First Group',
+        options: [{
+            id: 'sound-001',
+            name: 'Sound 1',
+            sound: 'https://example.com/sound-001.mp3'
+        }]
+    },
+    {
+        name: 'Second Group',
+        options: [{
+            id: 'sound-002',
+            name: 'Sound 2',
+            sound: 'https://example.com/sound-002.mp3'
+        }]
+    }
+]
+section.soundSetting('id').groupedOptions(groups)
+	 ```
+	 */
+	groupedOptions(groups) {
+		this._groupedOptions = groups
 		return this
 	}
 
+	/**
+	 * The sound options.
+	 *
+	 * @param {SoundOption | Array.<SoundOption>} options Single or array of sound options
+	 * @returns {SoundSetting} Sound Setting instance
+	 * @example
+	 *
+	 ```javascript
+const options = [{
+        id: 'sound-001',
+		name: 'Sound 1',
+		sound: 'https://example.com/sound-001.mp3'
+    },
+    {
+        id: 'sound-002',
+		name: 'Sound 2',
+		sound: 'https://example.com/sound-002.mp3'
+    }
+]
+section.soundSetting('id').options(options)
+	 ```
+	 */
 	options(value) {
 		this._options = value
 		return this
 	}
 
+	/**
+	 * Indicates if this input should refresh configs after a change in value.
+	 *
+	 * @param {Boolean} value Submit on change value
+	 * @default false
+	 * @returns {SoundSetting} Sound Setting instance
+	 */
 	submitOnChange(value) {
 		this._submitOnChange = value
 		return this
 	}
 
+	/**
+	 * Style of the setting.
+	 *
+	 * @param {('COMPLETE','ERROR','DEFAULT','DROPDOWN')} value
+	 * @returns {SoundSetting} Sound Setting instance
+	 */
 	style(value) {
 		this._style = value
 		return this

--- a/lib/pages/text-setting.js
+++ b/lib/pages/text-setting.js
@@ -9,23 +9,47 @@ module.exports = class TextSetting extends SectionSetting {
 		this._description = 'Tap to set'
 	}
 
+	/**
+	 * The maximum length the text can have.
+	 *
+	 * @param {number} value
+	 * @returns {TextSetting} Text Setting instance
+	 */
 	maxLength(value) {
 		this._maxLength = value
 		return this
 	}
 
+	/**
+	 * The minimum length the text can have.
+	 *
+	 * @param {number} value
+	 * @returns {TextSetting} Text Setting instance
+	 */
 	minLength(value) {
 		this._minLength = value
 		return this
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {TextSetting} Text Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 
-	postMessage(value) {
-		this._postMessage = value
+	/**
+	 * A string to be shown after the text input field.
+	 *
+	 * @param {String} text Max length 10 characters
+	 * @returns {TextSetting} Text Setting instance
+	 */
+	postMessage(text) {
+		this._postMessage = text
 		return this
 	}
 

--- a/lib/pages/time-setting.js
+++ b/lib/pages/time-setting.js
@@ -8,8 +8,36 @@ module.exports = class TimeSetting extends SectionSetting {
 		this._type = 'TIME'
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Set an image icon
+	 *
+	 * @param {String} source HTTPS url or Base64-encoded data URI. Max length 2048 characters.
+	 * @returns {TimeSetting} Time Setting instance
+	 */
+	image(source) {
+		this._image = source
+		return this
+	}
+
+	/**
+	 * The maximum inclusive value the time can be set to (only the time will be used out of the date time).
+	 *
+	 * @param {String} value DateTime
+	 * @returns {TimeSetting} Time Setting instance
+	 */
+	max(value) {
+		this._max = value
+		return this
+	}
+
+	/**
+	 * The minimum inclusive value the time can be set to (only the time will be used out of the date time).
+	 *
+	 * @param {String} value DateTime
+	 * @returns {TimeSetting} Time Setting instance
+	 */
+	min(value) {
+		this._min = value
 		return this
 	}
 

--- a/lib/pages/video-setting.js
+++ b/lib/pages/video-setting.js
@@ -8,13 +8,25 @@ module.exports = class VideoSetting extends SectionSetting {
 		this._type = 'VIDEO'
 	}
 
-	video(value) {
-		this._video = value
+	/**
+	 * Configure your video source
+	 *
+	 * @param {String} source HTTPS url. Max length 2048 characters.
+	 * @returns {VideoSetting} Video Setting instance
+	 */
+	video(source) {
+		this._video = source
 		return this
 	}
 
-	image(value) {
-		this._image = value
+	/**
+	 * Configure your video source
+	 *
+	 * @param {String} source HTTPS url. Max length 2048 characters.
+	 * @returns {VideoSetting} Video Setting instance
+	 */
+	image(source) {
+		this._image = source
 		return this
 	}
 

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -11,6 +11,25 @@ const EndpointContext = require('./util/endpoint-context')
 const Log = require('./util/log')
 
 module.exports = class SmartApp {
+	/**
+	 * @typedef {Object} SmartAppOptions
+	 * @prop {String} clientId
+	 * @prop {String} clientSecret
+	 * @prop {String} appId
+	 * @prop {Boolean} disableCustomDisplayName
+	 * @prop {Array.<String>|String} permissions
+	 * @prop {Boolean} disableRemoveApp
+	 * @prop {String} apiUrl
+	 * @prop {String} refreshUrl
+	 * @prop {String} logger
+	 * @prop {number} jsonSpace
+	 * @prop {Boolean} enableEventLogging
+	 * @prop {String} publicKey
+	 */
+	/**
+	 * Create a SmartApp instance
+	 * @param {SmartAppOptions} [options] Optionally, pass in a configuration object
+	 */
 	constructor(options = {}) {
 		this._clientId = options.clientId
 		this._clientSecret = options.clientSecret
@@ -47,31 +66,73 @@ module.exports = class SmartApp {
 	// App Initialization Options //
 	/// /////////////////////////////
 
-	appId(value) {
-		this._id = value
+	/**
+	 * Set your app identifier for use elsewhere in the app
+	 * @param {String} id A globally unique, developer-defined identifier
+	 * for an app. It is alpha-numeric, may contain dashes, underscores,
+	 * periods, and must be less then 250 characters long.
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	appId(id) {
+		this._id = id
 		return this
 	}
 
-	apiUrl(value) {
-		this._apiUrl = value
+	/**
+	 * Manually set the SmartThings API URL
+	 * @param {String} url
+	 * @default https://api.smartthings.com
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	apiUrl(url) {
+		this._apiUrl = url
 		return this
 	}
 
-	refreshUrl(value) {
-		this._refreshUrl = value
+	/**
+	 * Manually set the refresh token URL
+	 * @param {String} url
+	 * @default https://auth-global.api.smartthings.com/oauth/token
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	refreshUrl(url) {
+		this._refreshUrl = url
 		return this
 	}
 
-	clientId(value) {
-		this._clientId = value
+	/**
+	 * Set your smartapp automation's client id. Cannot be
+	 * acquired until your app has been created through the
+	 * Developer Workspace.
+	 * @param {String} id
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	clientId(id) {
+		this._clientId = id
 		return this
 	}
 
-	clientSecret(value) {
-		this._clientSecret = value
+	/**
+	 * Set your smartapp automation's client secret. Cannot be
+	 * acquired until your app has been created through the
+	 * Developer Workspace. This secret should never be shared
+	 * or committed into a public repository.
+	 * @param {String} secret
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	clientSecret(secret) {
+		this._clientSecret = secret
 		return this
 	}
 
+	/**
+	 * Add your public key so that our WebHook endpoint can verify
+	 * requests from SmartThings.
+	 *
+	 * https://smartthings.developer.samsung.com/docs/how-to/using-public-key-webhook-endpoint.html
+	 * @param {String} key public key to identify your app with SmartThings
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	publicKey(key) {
 		signature.setPublicKey(key)
 		return this
@@ -87,21 +148,62 @@ module.exports = class SmartApp {
 		return this
 	}
 
+	/**
+	 * Set app permissions as a string or array of strings.
+	 *
+	 * @example
+	 * // sets single permission
+	 * smartapp.permissions('r:devices:*')
+	 * @example
+	 * // sets multiple permissions
+	 * smartapp.permissions('r:devices:* r:locations:*')
+	 * @example
+	 * // sets multiple permissions
+	 * smartapp.permissions(['r:devices:*', 'r:locations:*'])
+	 * @param {Array<String> | String} value
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	permissions(value) {
 		this._permissions = value
 		return this
 	}
 
+	/**
+	 * Disable the ability for the user to customize the display name.
+	 *
+	 * @param {Boolean} [value=true]
+	 * @default true
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	disableCustomDisplayName(value = true) {
 		this._disableCustomDisplayName = value
 		return this
 	}
 
+	/**
+	 * Disable the ability to remove the app from the configuration flow.
+	 *
+	 * @param {Boolean} [value=true]
+	 * @default true
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	disableRemoveApp(value = true) {
 		this._disableRemoveApp = value
 		return this
 	}
 
+	/**
+	 * Provide a custom context store used for storing in-flight credentials
+	 * for each installed instance of the app.
+	 *
+	 * @param {*} value
+	 * @example Use the AWS DynamoDB plugin
+	 * smartapp.contextStore(new DynamoDBContextStore('aws-region', 'app-table-name'))
+	 * @example
+	 * // Use Firebase Cloud Firestore
+	 * smartapp.contextStore(new FirestoreDBContextStore(firebaseServiceAccount, 'app-table-name'))
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	contextStore(value) {
 		this._contextStore = value
 		return this
@@ -121,15 +223,56 @@ module.exports = class SmartApp {
 		return this
 	}
 
-	firstPageId(value) {
-		this._firstPageId = value
+	/**
+	 * The first page users will see when they open configuration.
+	 *
+	 * @param {String} pageId A developer defined page ID. Must
+	 * be URL safe characters.
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	firstPageId(pageId) {
+		this._firstPageId = pageId
 		return this
 	}
 
-	/// /////////////////////
-	// Configuration/Page //
-	/// /////////////////////
+	/// //////////////////////
+	// Configuration/Page   //
+	/// //////////////////////
 
+	/**
+	 * @typedef ConfigurationData
+	 * @property {String=} installedAppId The id of the installed app.
+	 * @property {String} phase Denotes the current installation phase.
+	 * @property {String=} pageId A developer defined page ID. Must be URL
+	 * safe characters.
+	 * @property {String=} previousPageId The previous page the user
+	 * completed. Must be URL safe characters.
+	 * @property {Object=} config A map of configurations for an Installed App.
+	 * The map 'key' is the configuration name and the 'value' is an array
+	 * of strings.
+	 */
+
+	/**
+	 * @callback PageCallback
+	 * @param context { import("./util/endpoint-context") } EndpointContext to
+	 * access config values associated to the installed app
+	 * @param page { import("./pages/page") } Chainable page instance
+	 * @param {ConfigurationData} data Optionally access the raw configuration
+	 * data event object
+	 * @returns {SmartApp} SmartApp instance
+	 */
+
+	/**
+	 * Define a configuration page – you may chain as many pages as is
+	 * necessary to satisfy your configuration needs. Please see the
+	 * the documentation on how to design pages for your automation.
+	 *
+	 * https://smartthings.developer.samsung.com/docs/how-to/design-pages-smartapp.html
+	 * @param {String} id Identify your page with a unique snake_case or
+	 * camelCase identifier, used for i18n keys
+	 * @param {PageCallback} callback Allows you to define config page
+	 * characteristics and access config values
+	 */
 	page(id, callback) {
 		if (!this._firstPageId) {
 			this._firstPageId = id
@@ -139,70 +282,141 @@ module.exports = class SmartApp {
 		return this
 	}
 
-	/// //////////
-	// Install //
-	/// //////////
+	/// ///////////
+	// Install  //
+	/// ///////////
 
 	installed(callback) {
 		this._installedHandler = callback
 		return this
 	}
 
-	/// //////////
-	// Update  //
-	/// //////////
+	/// ///////////
+	// Update   //
+	/// ///////////
 
 	updated(callback) {
 		this._updatedHandler = callback
 		return this
 	}
 
-	/// ////////////
-	// Uninstall //
-	/// ////////////
+	/// /////////////
+	// Uninstall  //
+	/// /////////////
 
 	uninstalled(callback) {
 		this._uninstalledHandler = callback
 		return this
 	}
 
-	/// //////////
-	// Events  //
-	/// //////////
+	/// ///////////
+	// Events   //
+	/// ///////////
 
 	oauthHandler(callback) {
 		this._oauthHandler = callback
 		return this
 	}
 
+	/**
+	 * @typedef {Object} ModeEvent
+	 * @property {String} eventId The id of the event
+	 * @property {String} locationId The id of the location in which the event was triggered.
+	 * @property {String} modeId The ID of the mode associated with a MODE_EVENT.
+	 */
+
+	/**
+	 * @typedef {Object} DeviceEvent An event on a device that matched a subscription for this app.
+	 * @property {String} eventId The ID of the event.
+	 * @property {String} locationId The ID of the location in which the event was triggered.
+	 * @property {String} deviceId The ID of the location in which the event was triggered.
+	 * @property {String} componentId The name of the component on the device that the event is associated with.
+	 * @property {String} capability The name of the capability associated with the DEVICE_EVENT.
+	 * @property {String} attribute The name of the DEVICE_EVENT. This typically corresponds to an attribute name of the device-handler’s capabilities.
+	 * @property {Object} value The value of the event. The type of the value is dependent on the capability's attribute type.
+	 * @property {String} valueType The root level data type of the value field. The data types are representitive of standard JSON data types.
+	 * @property {Boolean} stateChange Whether or not the state of the device has changed as a result of the DEVICE_EVENT.
+	 * @property {Map} data json map as defined by capability data schema
+	 * @property {String} subscriptionName The name of subscription that caused delivery.
+	 */
+
+	/**
+	 * @typedef {Object} TimerEvent
+	 * @property {String} eventId The ID of the event.
+	 * @property {String} name The name of the schedule that caused this event.
+	 * @property {Object} type
+	 * @property {String} time The IS0-8601 date time strings in UTC that this event was scheduled for.
+	 * @property {String} expression The CRON expression if the schedule was of type CRON.
+	 */
+
+	/**
+	 * @callback EventCallback
+	 * @param context { import('./util/endpoint-context') }
+	 * @param {ModeEvent|DeviceEvent|TimerEvent} event
+	 * @returns {EventCallback}
+	 */
+
+	/**
+	 * Handler for named subscriptions to events
+	 *
+	 * @param {String} name Provide the name matching a created subscription
+	 * @param {EventCallback} callback Callback handler object
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	subscribedEventHandler(name, callback) {
 		this._subscribedEventHandlers[name] = callback
 		return this
 	}
 
+	/**
+	 * Handler for named subscriptions to **scheduled** events
+	 *
+	 * @param {String} name Provide the name matching a created subscription
+	 * @param {Object} callback Callback handler object
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	scheduledEventHandler(name, callback) {
 		this._scheduledEventHandlers[name] = callback
 		return this
 	}
 
+	/**
+	 * Handler for device commands
+	 *
+	 * @param {Object} callback Callback handler object
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	deviceCommandHandler(callback) {
 		this._deviceCommandHandler = callback
 		return this
 	}
 
+	/**
+	 * Handler for device commands
+	 *
+	 * @param {Object} callback Callback handler object
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	defaultDeviceCommandHandler(callback) {
 		this._defaultDeviceCommandHandler = callback
 		return this
 	}
 
+	/**
+	 * Device command and callback
+	 *
+	 * @param {String} command Device command
+	 * @param {Object} callback Callback handler object
+	 * @returns {SmartApp} SmartApp instance
+	 */
 	deviceCommand(command, callback) {
 		this._deviceCommands[command] = callback
 		return this
 	}
 
-	/// /////////////
-	// Utilities  //
-	/// /////////////
+	/// //////////////
+	// Utilities   //
+	/// //////////////
 
 	translate(...args) {
 		if (this._localizationEnabled) {
@@ -212,10 +426,23 @@ module.exports = class SmartApp {
 		return args[0]
 	}
 
+	/**
+	 * Use with an AWS Lambda function. No signature verification is required.
+	 *
+	 * @param {*} event
+	 * @param {*} context
+	 * @param {*} callback
+	 */
 	handleLambdaCallback(event, context, callback) {
 		this._handleCallback(event, responders.lambdaResponse(callback, this._log))
 	}
 
+	/**
+	 * Use with a standard HTTP webhook endpoint app. Signature verification is required.
+	 *
+	 * @param {*} request
+	 * @param {*} response
+	 */
 	handleHttpCallback(request, response) {
 		if (request.body && (request.body.lifecycle === 'PING' || signature.signatureIsVerified(request))) {
 			this._handleCallback(request.body, responders.httpResponder(response, this._log))
@@ -225,10 +452,22 @@ module.exports = class SmartApp {
 		}
 	}
 
+	/**
+	 * Use with a standard HTTP webhook endpoint app, but
+	 * disregard the HTTP verification process.
+	 *
+	 * @param {*} request
+	 * @param {*} response
+	 */
 	handleHttpCallbackUnverified(request, response) {
 		this._handleCallback(request.body, responders.httpResponder(response, this._log))
 	}
 
+	/**
+	 * Used for internal unit testing.
+	 *
+	 * @param {Object} body
+	 */
 	async handleMockCallback(body) {
 		const responder = responders.mockResponder(this._log)
 		await this._handleCallback(body, responder)

--- a/lib/util/endpoint-context.js
+++ b/lib/util/endpoint-context.js
@@ -7,6 +7,9 @@ module.exports = class EndpointContext {
 	constructor(app, evt, apiMutex) {
 		this.event = evt
 
+		/** @type { import('../api') } */
+		this.api = {}
+
 		let authToken
 		let refreshToken
 		switch (evt.lifecycle) {

--- a/lib/util/signature.js
+++ b/lib/util/signature.js
@@ -6,6 +6,13 @@ const httpSignature = require('http-signature')
 let publicKey = 'INVALID'
 
 module.exports = {
+
+	/**
+	 * Set the public key with raw text, or point to a file with the prefix `@`
+	 *
+	 * @param {String} key Key contents or key path
+	 * @returns {Object} Public key
+	 */
 	setPublicKey(key) {
 		if (key.startsWith('@')) {
 			publicKey = fs.readFileSync(key.slice(1), 'utf8')
@@ -16,6 +23,12 @@ module.exports = {
 		return publicKey
 	},
 
+	/**
+	 * Confirms if key is verified or not
+	 *
+	 * @param {*} req HTTP request
+	 * @returns {Boolean}
+	 */
 	signatureIsVerified(req) {
 		try {
 			const parsed = httpSignature.parseRequest(req)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/smartapp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -128,9 +128,9 @@
       "dev": true
     },
     "@octokit/endpoint": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
-      "integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-4.0.0.tgz",
+      "integrity": "sha512-b8sptNUekjREtCTJFpOfSIL4SKh65WaakcyxWzRcSPOk5RxkZJ/S8884NGZFxZ+jCB2rDURU66pSHn14cVgWVg==",
       "dev": true,
       "requires": {
         "deepmerge": "3.2.0",
@@ -140,30 +140,35 @@
       }
     },
     "@octokit/request": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.0.tgz",
-      "integrity": "sha512-Bm2P0duVRUeKhyepNyFg5GX+yhCK71fqdtpsw5Rz+PQPjSha8HYwPMF5QfpzpD8b6/Xl3xhTgu3V90W362gZ1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-3.0.0.tgz",
+      "integrity": "sha512-DZqmbm66tq+a9FtcKrn0sjrUpi0UaZ9QPUCxxyk/4CJ2rseTMpAWRf6gCwOSUCzZcx/4XVIsDk+kz5BVdaeenA==",
       "dev": true,
       "requires": {
-        "@octokit/endpoint": "^3.1.1",
+        "@octokit/endpoint": "^4.0.0",
+        "deprecation": "^1.0.1",
         "is-plain-object": "^2.0.4",
         "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
         "universal-user-agent": "^2.0.1"
       }
     },
     "@octokit/rest": {
-      "version": "16.16.3",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.16.3.tgz",
-      "integrity": "sha512-8v5xyqXZwQbQ1WsTLU3G25nAlcKYEgIXzDeqLgTFpbzzJXcey0C8Mcs/LZiAgU8dDINZtO2dAPgd1cVKgK9DQw==",
+      "version": "16.23.5",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.23.5.tgz",
+      "integrity": "sha512-7RcYNXeBvmKdbXdaRGCDzaq8snEaZrD7X+jUFT6ZjEMNgaSYrkl7pB+ICh+dnTpubAeFPpxeKR+82msCbgxqew==",
       "dev": true,
       "requires": {
-        "@octokit/request": "2.4.0",
-        "before-after-hook": "^1.2.0",
+        "@octokit/request": "3.0.0",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
+        "deprecation": "^1.0.1",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lodash.uniq": "^4.5.0",
         "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       }
@@ -350,9 +355,9 @@
       }
     },
     "aggregate-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-2.1.0.tgz",
-      "integrity": "sha512-rIZJqC4XACGWwmPpi18IhDjIzXTJ93KQwYHXuyMCa0Ak9mtzLIbykuei+0i5EnGDy6ts8JVnSyRnZc2cVIMvVg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-2.2.0.tgz",
+      "integrity": "sha512-E5n+IZkhh22/pFdUvHUU/o9z752lc+7tgHt+FXS/g6BjlbE9249dGmuS/SxIWMPhTljZJkFN+7OXE0+O5+WT8w==",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -408,6 +413,12 @@
       "requires": {
         "string-width": "^2.0.0"
       }
+    },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -574,6 +585,12 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
+      "dev": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -653,15 +670,15 @@
       }
     },
     "before-after-hook": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz",
-      "integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
       "dev": true
     },
     "bottleneck": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.17.0.tgz",
-      "integrity": "sha512-0WpG/tVEBkhl9LLAFcjMTWhzQvLCYTD4wNlvtf+BZ9Q9xkMVpP5TbGPKkj2sADZtC/GQqgUMF2ij/7nD3abFLg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.18.0.tgz",
+      "integrity": "sha512-U1xiBRaokw4yEguzikOl0VrnZp6uekjpmfrh6rKtr1D+/jFjYCL6J83ZXlGtlBDwVdTmJJ+4Lg5FpB3xmLSiyA==",
       "dev": true
     },
     "boxen": {
@@ -910,9 +927,9 @@
       }
     },
     "clean-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
-      "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
+      "integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
       "dev": true
     },
     "cli-boxes": {
@@ -1050,10 +1067,11 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-      "dev": true
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true,
+      "optional": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -1357,15 +1375,14 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+      "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
       "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "lodash.get": "^4.4.2",
+        "js-yaml": "^3.13.0",
         "parse-json": "^4.0.0"
       },
       "dependencies": {
@@ -1581,6 +1598,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "deprecation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
+      "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==",
+      "dev": true
     },
     "detect-indent": {
       "version": "5.0.0",
@@ -2685,9 +2708,26 @@
       },
       "dependencies": {
         "array-uniq": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
-          "integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+          "integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
+          "dev": true
+        }
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
           "dev": true
         }
       }
@@ -3028,26 +3068,17 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.11"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3147,15 +3178,15 @@
       "dev": true
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "hook-std": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-1.2.0.tgz",
-      "integrity": "sha512-yntre2dbOAjgQ5yoRykyON0D9T96BfshR8IuiL/r3celeHD8I/76w4qo8m3z99houR4Z678jakV3uXrQdSvW/w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
       "dev": true
     },
     "hosted-git-info": {
@@ -3860,9 +3891,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -4204,9 +4235,9 @@
       }
     },
     "macos-release": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
-      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==",
       "dev": true
     },
     "make-dir": {
@@ -4265,9 +4296,9 @@
       }
     },
     "marked": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.1.tgz",
-      "integrity": "sha512-+H0L3ibcWhAZE02SKMqmvYsErLo4EAVJxu5h3bHBBDvvjeWXtl92rGUSBYHL2++5Y+RSNgl8dYOAXcYe7lp1fA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==",
       "dev": true
     },
     "marked-terminal": {
@@ -4427,9 +4458,9 @@
       }
     },
     "mime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+      "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
       "dev": true
     },
     "mime-db": {
@@ -4513,37 +4544,100 @@
       }
     },
     "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.3.tgz",
+      "integrity": "sha512-QdE/w//EPHrqgT5PNRUjRVHy6IJAzAf1R8n2O8W8K2RZ+NbPfOD5cBDp+PGa2Gptep37C/TdBiaNwakppEzEbg==",
       "dev": true,
       "requires": {
+        "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
+        "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
         "growl": "1.10.5",
-        "he": "1.1.1",
+        "he": "1.2.0",
+        "js-yaml": "3.13.0",
+        "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.2.2",
+        "yargs-parser": "13.0.0",
+        "yargs-unparser": "1.5.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
           }
         },
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -4554,19 +4648,161 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "ms": {
+        "invert-kv": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
+        "js-yaml": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+          "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+          "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+          "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -4638,6 +4874,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
     "nerf-dart": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
@@ -4657,6 +4899,24 @@
       "dev": true,
       "requires": {
         "lodash.toarray": "^4.4.0"
+      }
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "node-fetch": {
@@ -4686,9 +4946,9 @@
       }
     },
     "normalize-url": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.2.0.tgz",
-      "integrity": "sha512-n69+KXI+kZApR+sPwSkoAXpGlNkaiYyoHHqKOFPjJWvwZpew/EjKvuPE4+tStNgb42z5yLtdakgZCQI+LalSPg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
       "dev": true
     },
     "npm": {
@@ -8903,6 +9163,18 @@
         "isobject": "^3.0.0"
       }
     },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
     "object.entries": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
@@ -8913,6 +9185,16 @@
         "es-abstract": "^1.12.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.pick": {
@@ -9022,12 +9304,12 @@
       }
     },
     "os-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
-      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
       "dev": true,
       "requires": {
-        "macos-release": "^2.0.0",
+        "macos-release": "^2.2.0",
         "windows-release": "^3.1.0"
       }
     },
@@ -9059,9 +9341,9 @@
       "dev": true
     },
     "p-is-promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
@@ -9089,9 +9371,9 @@
       "dev": true
     },
     "p-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
-      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
       "dev": true
     },
     "p-retry": {
@@ -9718,13 +10000,14 @@
       }
     },
     "semantic-git-commit-cli": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semantic-git-commit-cli/-/semantic-git-commit-cli-3.1.1.tgz",
-      "integrity": "sha512-/HHS/g/eNsaJH6ya7OXUu3Yw3sEyY58GNb4+inv5e4RefASyUuFimIAZpG6YVy+WL/bEZ9P4Ck3hLnqmjqEcEA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/semantic-git-commit-cli/-/semantic-git-commit-cli-3.2.2.tgz",
+      "integrity": "sha512-mf/u/yvn9tJlsnZ4U13dvfb6egCUjdDTlIUDfaz4UbUMZb/H8zvvmpvG9u96rQPrxFYbazbDVsuEwhXzLc9D7g==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "execa": "^0.6.1",
+        "fs-extra": "^7.0.0",
         "git-commit-count": "^1.1.2",
         "inquirer": "^6.2.1",
         "is-git-added": "^1.0.1",
@@ -9732,6 +10015,8 @@
         "json-extra": "^0.5.0",
         "lodash.merge": "^4.6.0",
         "object.entries": "^1.0.4",
+        "path-is-absolute": "^2.0.0",
+        "temp-dir": "^1.0.0",
         "update-notifier": "^2.1.0",
         "yargs": "^7.0.2"
       },
@@ -9854,6 +10139,12 @@
             "pinkie-promise": "^2.0.0"
           }
         },
+        "path-is-absolute": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-2.0.0.tgz",
+          "integrity": "sha512-ajROpjq1SLxJZsgSVCcVIt+ZebVH+PwJtPnVESjfg6JKwJGwAgHRC3zIcjvI0LnecjIHCJhtfNZ/Y/RregqyXg==",
+          "dev": true
+        },
         "path-type": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -9960,9 +10251,9 @@
       }
     },
     "semantic-release": {
-      "version": "15.13.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.3.tgz",
-      "integrity": "sha512-cax0xPPTtsxHlrty2HxhPql2TTvS74Ni2O8BzwFHxNY/mviVKEhI4OxHzBYJkpVxx1fMVj36+oH7IlP+SJtPNA==",
+      "version": "15.13.9",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.9.tgz",
+      "integrity": "sha512-EKm23KsIAfq1P9dMx8y7YmMHvWZRvmEEUE7z9FXQy2iY1k4jeeRYJTab1aykbYJ1Vj2p9mtkPo59Yi7YVsPUdw==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^6.1.0",
@@ -9977,26 +10268,32 @@
         "execa": "^1.0.0",
         "figures": "^2.0.0",
         "find-versions": "^3.0.0",
-        "get-stream": "^4.0.0",
+        "get-stream": "^5.0.0",
         "git-log-parser": "^1.2.0",
-        "hook-std": "^1.1.0",
+        "hook-std": "^2.0.0",
         "hosted-git-info": "^2.7.1",
         "lodash": "^4.17.4",
         "marked": "^0.6.0",
         "marked-terminal": "^3.2.0",
-        "p-locate": "^3.0.0",
-        "p-reduce": "^1.0.0",
-        "read-pkg-up": "^4.0.0",
+        "p-locate": "^4.0.0",
+        "p-reduce": "^2.0.0",
+        "read-pkg-up": "^5.0.0",
         "resolve-from": "^4.0.0",
         "semver": "^5.4.1",
         "signale": "^1.2.1",
-        "yargs": "^12.0.0"
+        "yargs": "^13.1.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
         "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "execa": {
@@ -10012,6 +10309,17 @@
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+              "dev": true,
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            }
           }
         },
         "find-up": {
@@ -10023,10 +10331,16 @@
             "locate-path": "^3.0.0"
           }
         },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
         "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -10047,18 +10361,6 @@
             "invert-kv": "^2.0.0"
           }
         },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -10067,18 +10369,35 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          },
+          "dependencies": {
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            }
           }
         },
         "mem": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-          "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^1.0.0",
+            "mimic-fn": "^2.0.0",
             "p-is-promise": "^2.0.0"
           }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
@@ -10092,27 +10411,27 @@
           }
         },
         "p-limit": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
         },
         "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "^2.2.0"
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
         "parse-json": {
@@ -10125,66 +10444,81 @@
             "json-parse-better-errors": "^1.0.1"
           }
         },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
         "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.0.0.tgz",
+          "integrity": "sha512-OWufaRc67oJjcgrxckW/qO9q22iYzyiONh8h+GMcnOvSHAmhV1Dr3x+gyRjP+Qxc5jKupkSfoCQLS/98rDPh9A==",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "parse-json": "^4.0.0"
           }
         },
         "read-pkg-up": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
+          "integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
+            "read-pkg": "^5.0.0"
           }
         },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
         "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "version": "13.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+          "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
             "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
+            "require-main-filename": "^2.0.0",
             "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
+            "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.0.0"
           }
         },
         "yargs-parser": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+          "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -10747,6 +11081,12 @@
         "csextends": "^1.0.3"
       }
     },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "dev": true
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -10980,23 +11320,16 @@
       "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M="
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+      "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true,
-          "optional": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11229,6 +11562,15 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
     "widest-line": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
@@ -11239,27 +11581,36 @@
       }
     },
     "windows-release": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
-      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
       "dev": true,
       "requires": {
-        "execa": "^0.10.0"
+        "execa": "^1.0.0"
       },
       "dependencies": {
         "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
             "signal-exit": "^3.0.0",
             "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
           }
         }
       }
@@ -11631,6 +11982,165 @@
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "smartthings",
     "smartapp"
   ],
-  "main": "index.js",
+  "main": "lib/smart-app.js",
   "scripts": {
     "lint": "xo",
-    "test": "xo && nyc mocha test/**/*.js"
+    "test": "xo && nyc mocha test/**/*.js",
+    "start": "node ./smart-app.js",
+    "debug": "node --inspect ./lib/smart-app.js"
   },
   "engines": {
     "node": ">=8.9.4"
@@ -26,22 +28,22 @@
   },
   "homepage": "https://github.com/SmartThingsCommunity/smartapp-sdk-nodejs#readme",
   "dependencies": {
-    "async-mutex": "^0.1.3",
-    "fs-extra": "^7.0.1",
-    "http-signature": "^1.2.0",
-    "i18n": "^0.8.3",
-    "request": "^2.88.0",
+    "async-mutex": "~0.1.3",
+    "fs-extra": "~7.0.1",
+    "http-signature": "~1.2.0",
+    "i18n": "~0.8.3",
+    "request": "~2.88.0",
     "request-promise-native": "^1.0.7",
-    "winston": "^3.2.1"
+    "winston": "~3.2.1"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "conventional-changelog-eslint": "^3.0.1",
-    "mocha": "^5.2.0",
-    "nyc": "^13.3.0",
-    "semantic-git-commit-cli": "^3.1.1",
-    "semantic-release": "^15.13.3",
-    "xo": "^0.24.0"
+    "chai": "~4.2.0",
+    "conventional-changelog-eslint": "~3.0.1",
+    "mocha": "^6.1.3",
+    "nyc": "~13.3.0",
+    "semantic-git-commit-cli": "~3.2.2",
+    "semantic-release": "^15.13.9",
+    "xo": "~0.24.0"
   },
   "xo": {
     "space": false,

--- a/test/boolean-setting-spec.js
+++ b/test/boolean-setting-spec.js
@@ -1,0 +1,36 @@
+/* eslint no-undef: "off" */
+const {expect} = require('chai')
+const Page = require('../lib/pages/page')
+const Section = require('../lib/pages/section')
+const BooleanSetting = require('../lib/pages/boolean-setting')
+
+describe('boolean-setting', () => {
+	let page = {}
+	let section = {}
+
+	beforeEach(() => {
+		page = new Page('testPage')
+		section = new Section(page, 'testSection')
+	})
+
+	it('should set type to BOOLEAN', () => {
+		const setting = new BooleanSetting(section, 'testSetting')
+		setting.name('testBoolean')
+		const json = setting.toJson()
+		expect(json.type).to.equal('BOOLEAN')
+		expect(json.name).to.equal('testBoolean')
+	})
+
+	it('should set an image url when set', () => {
+		const setting = new BooleanSetting(section, 'id')
+		setting.image('https://example.com/image.png')
+		const json = setting.toJson()
+		expect(json.image).to.equal('https://example.com/image.png')
+	})
+
+	it('should not include image in json when unset', () => {
+		const setting = new BooleanSetting(section, 'id')
+		const json = setting.toJson()
+		expect(json).to.not.have.property('image')
+	})
+})


### PR DESCRIPTION
Closes #52
Closes #44
Closes #53

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - one minor change, not truly breaking change – need to use the `new` keyword.
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

**WIP** ~because I know I have broken tests and need to fix some issues yet~ tests fixed

_note: It's hard to see the value of these changes until you play with it, so I'm including a lot of descriptions/images._

This PR is almost entirely to improve developer experience. I had previously unknowingly led @bflorian down the wrong path with how we were creating the instance in `index.js` (_sorry about that_). It ended up breaking *completions* entirely and it made it excruciatingly hard to use the SDK. So I rolled that back a bit – you have to instantiate the object a little differently with the `new` keyword. 
![image](https://user-images.githubusercontent.com/1534259/56102301-cd89cc00-5ef1-11e9-96d7-f285c1046ec2.png)


A huge part of this PR is adding JSdocs. It's pretty rough doing it by hand but I just didn't see any way to generate these docs from our swagger spec yet (maybe some time in the future..). It seemed important enough in the near term to make it worth doing it by hand (e.g., for our IoTFuse workshop contributors at end of April). Here's what it looks like in one case, where adding permissions to your app can be a little confusing. That function supports multiple inputs, so the completion dialog includes a 3 examples of how you can do it.
![image](https://user-images.githubusercontent.com/1534259/56102233-69ff9e80-5ef1-11e9-8141-744c27fba5f1.png)

Auto complete will guide the developer on how to structure their callbacks now, and what they provide. For example: Page `context` now includes `EndpointContext` docs.
![image](https://user-images.githubusercontent.com/1534259/56102388-6d475a00-5ef2-11e9-9790-1c6b31c066cf.png)

Page Sections now show what SectionSettings you can use
![image](https://user-images.githubusercontent.com/1534259/56102429-a7b0f700-5ef2-11e9-8478-264ae2d1fe6e.png)

SectionSetting types show better detail (like URL limitations) too
![image](https://user-images.githubusercontent.com/1534259/56102487-ee9eec80-5ef2-11e9-946b-764b70ed93bc.png)

Additionally, event handlers now have `context.api` completions (though not 100% fleshed out) so you can navigate it a little better at least.
![image](https://user-images.githubusercontent.com/1534259/56102599-a2a07780-5ef3-11e9-9f86-24b4eea70a61.png)

And the subscription event handler's `event` now includes a few event type models. It's not ideal, as it shows all three, because it's a generic function that is used for multiple different types. 
![image](https://user-images.githubusercontent.com/1534259/56102638-f3b06b80-5ef3-11e9-9c4e-814baec65b95.png)

A developer can also actually pass in an `options` object in the constructor instead of using the chained functions. Our jsdocs also guide them as to what options they can utilize here:
![image](https://user-images.githubusercontent.com/1534259/56103217-4b040b00-5ef7-11e9-953f-644b2cdd6818.png)

