### PR TITLE
fix: Added default unhandled promise rejection handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ Configuration page strings are specified in a separate `locales/en.json` file, w
 }
 ```
 
+### Unhandled Promise Rejection Handling
+
+By default, instation of the SmartApp object registers an "unhandledReject" handler 
+that logs unhandled promise rejections. If you don't want this behavior you can disable
+it by passing an option to the SmartApp instantion, e.g. `new SmartApp({logUnhandedRejections: false})`.
+If you want to replace the handler you can do that by calling `unhandledRejectionHandler(promise => {...})`
+on the SmartApp object.
+
 ### Making API calls outside of an EVENT handler
 
 By default, the SmartApp SDK will facilitate API calls on behalf of a user within the `EVENT` lifecycle. These user tokens are ephemeral and last *5 minutes*. These access tokens are not able to be refreshed and should _not_ be stored. If you're making out-of-band API calls on behalf of a user's installed app, you will need to use the 24-hour access token that are supplied after `INSTALL` and `UPDATE` lifecycles. This token includes a `refresh_token`, and will be automatically refreshed by the SDK when necessary.

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Configuration page strings are specified in a separate `locales/en.json` file, w
 
 ### Unhandled Promise Rejection Handling
 
-By default, instation of the SmartApp object registers an "unhandledReject" handler 
+By default, instantiation of the SmartApp object registers an "unhandledReject" handler 
 that logs unhandled promise rejections. If you don't want this behavior you can disable
-it by passing an option to the SmartApp instantion, e.g. `new SmartApp({logUnhandedRejections: false})`.
+it by passing an option to the SmartApp instantiation, e.g. `new SmartApp({logUnhandledRejections: false})`.
 If you want to replace the handler you can do that by calling `unhandledRejectionHandler(promise => {...})`
 on the SmartApp object.
 

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -25,6 +25,7 @@ module.exports = class SmartApp {
 	 * @prop {number} jsonSpace
 	 * @prop {Boolean} enableEventLogging
 	 * @prop {String} publicKey
+	 * @prop {Boolean} logUnhandedRejections
 	 */
 	/**
 	 * Create a SmartApp instance
@@ -59,6 +60,14 @@ module.exports = class SmartApp {
 
 		if (options.publicKey) {
 			signature.setPublicKey(options.publicKey)
+		}
+
+		this._unhandledRejectionHandler = reason => {
+			this._log.exception(reason)
+		}
+
+		if (options.logUnhandedRejections !== false) {
+			process.on('unhandledRejection', this._unhandledRejectionHandler)
 		}
 	}
 
@@ -206,6 +215,16 @@ module.exports = class SmartApp {
 	 */
 	contextStore(value) {
 		this._contextStore = value
+		return this
+	}
+
+	/**
+	 * Replaces the default unhandled rejection handler. If you don't want to
+	 *
+	 * @param {Function} callback when a promise rejection is not handled
+	 * @returns {SmartApp} SmartApp instance */
+	unhandledRejectionHandler(callback) {
+		this._unhandledRejectionHandler = callback
 		return this
 	}
 

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -25,7 +25,7 @@ module.exports = class SmartApp {
 	 * @prop {number} jsonSpace
 	 * @prop {Boolean} enableEventLogging
 	 * @prop {String} publicKey
-	 * @prop {Boolean} logUnhandedRejections
+	 * @prop {Boolean} logUnhandledRejections
 	 */
 	/**
 	 * Create a SmartApp instance
@@ -66,7 +66,7 @@ module.exports = class SmartApp {
 			this._log.exception(reason)
 		}
 
-		if (options.logUnhandedRejections !== false) {
+		if (options.logUnhandledRejections !== false) {
 			process.on('unhandledRejection', this._unhandledRejectionHandler)
 		}
 	}
@@ -219,7 +219,8 @@ module.exports = class SmartApp {
 	}
 
 	/**
-	 * Replaces the default unhandled rejection handler. If you don't want to
+	 * Replaces the default unhandled rejection handler. If you don't want to have a default handler at
+	 * all then instantiate the app with new SmartApp({logUnhandledRejections: false})
 	 *
 	 * @param {Function} callback when a promise rejection is not handled
 	 * @returns {SmartApp} SmartApp instance */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/smartapp",
-  "version": "1.1.1",
+  "version": "1.1.4",
   "description": "NodeJS SDK for SmartApps",
   "displayName": "SmartThings SmartApp SDK for NodeJS",
   "author": "SmartThings",


### PR DESCRIPTION
Added default handler for promise rejections that aren't explicitly caught in the SmartApp code, so that useful error messages are logged for things like failed API calls.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
