### PR TITLE
fix: Allow context initialization without data store

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -498,11 +498,17 @@ module.exports = class SmartApp {
 	// Proactive API calls (not in response to lifecycle events //
 	/// ///////////////////////////////////////////////////////////
 
-	withContext(installedAppId) {
+	withContext(installedAppIdOrObject) {
 		const app = this
+		if (typeof installedAppIdOrObject === 'object') {
+			return new Promise(resolve => {
+				resolve(new EndpointContext(app, installedAppIdOrObject, new Mutex()))
+			})
+		}
+
 		if (this._contextStore) {
 			return new Promise((resolve, reject) => {
-				this._contextStore.get(installedAppId).then(data => {
+				this._contextStore.get(installedAppIdOrObject).then(data => {
 					resolve(new EndpointContext(app, data, new Mutex()))
 				}).catch(error => {
 					reject(error)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/smartapp",
-  "version": "1.1.4",
+  "version": "1.2.1",
   "description": "NodeJS SDK for SmartApps",
   "displayName": "SmartThings SmartApp SDK for NodeJS",
   "author": "SmartThings",

--- a/test/smartapp-context-spec.js
+++ b/test/smartapp-context-spec.js
@@ -1,0 +1,101 @@
+/* eslint no-undef: "off" */
+
+const assert = require('assert').strict
+const SmartApp = require('../lib/smart-app')
+
+class ContextStore {
+	constructor() {
+		this.contexts = {}
+	}
+
+	get(installedAppId) {
+		return new Promise(resolve => {
+			resolve(this.contexts[installedAppId])
+		})
+	}
+
+	put(params) {
+		this.contexts[params.installedAppId] = params
+		return new Promise(resolve => {
+			resolve()
+		})
+	}
+
+	update(installedAppId, params) {
+		this.contexts[params.installedAppId].authToken = params.authToken
+		this.contexts[params.installedAppId].refreshToken = params.refreshToken
+		return new Promise(resolve => {
+			resolve()
+		})
+	}
+
+	delete(installedAppId) {
+		this.contexts[installedAppId] = null
+		return new Promise(resolve => {
+			resolve()
+		})
+	}
+}
+
+describe('smartapp-context-spec', () => {
+	let app
+
+	beforeEach(() => {
+		app = new SmartApp()
+	})
+
+	it('should handle context store', async () => {
+		const installData = {
+			authToken: 'xxx',
+			refreshToken: 'yyy',
+			installedApp: {
+				installedAppId: 'd692699d-e7a6-400d-a0b7-d5be96e7a564',
+				locationId: 'e675a3d9-2499-406c-86dc-8a492a886494',
+				config: {}
+			}
+		}
+
+		const contextStore = new ContextStore()
+		app.contextStore(contextStore)
+
+		await app.handleMockCallback({
+			lifecycle: 'INSTALL',
+			executionId: 'e6903fe6-f88f-da69-4c12-e2802606ccbc',
+			locale: 'en',
+			version: '0.1.0',
+			client: {
+				os: 'ios',
+				version: '0.0.0',
+				language: 'en-US'
+			},
+			installData,
+			settings: {}
+		})
+
+		const ctx = await app.withContext('d692699d-e7a6-400d-a0b7-d5be96e7a564')
+
+		assert.equal(installData.installedApp.installedAppId, ctx.installedAppId)
+		assert.equal(installData.installedApp.locationId, ctx.locationId)
+		assert.equal(installData.authToken, ctx.api.client.authToken)
+		assert.equal(installData.refreshToken, ctx.api.client.refreshToken)
+	})
+
+	it('should handle context object', async () => {
+		const params = {
+			authToken: 'xxx',
+			refreshToken: 'yyy',
+			installedAppId: 'aaa',
+			locationId: 'bbb',
+			locale: 'en',
+			config: {device: 'ccc'}
+		}
+
+		const ctx = await app.withContext(params)
+
+		assert.equal(params.installedAppId, ctx.installedAppId)
+		assert.equal(params.locationId, ctx.locationId)
+		assert.equal(params.authToken, ctx.api.client.authToken)
+		assert.equal(params.refreshToken, ctx.api.client.refreshToken)
+		assert.equal(params.locale, ctx.event.locale)
+	})
+})


### PR DESCRIPTION
Allow API context (access tokens and UUIDs) to be initialized from a simple parameter map as an alternative to using one of the context store modules. This feature is particularly handy for API apps that don't receive lifecycle events and therefore don't benefit from the built-in context persistence behavior. Instead the context is stored any way the app wants and is just passed into the SDK.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
