### PR TITLE
refactor(authorizer): authorizer polish

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,7 @@
 # Basic example of SmartApp SDK
 
 ## Steps to run
+
 * `node server.js`
 * `ngrok http 5555`
 * Register an Automation in [developer workspace](https://devworkspace.developer.samsung.com/).

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -60,7 +60,12 @@ module.exports = class SmartApp {
 		this._apiUrl = options.apiUrl ? options.apiUrl : 'https://api.smartthings.com'
 		this._refreshUrl = options.refreshUrl ? options.refreshUrl : 'https://auth-global.api.smartthings.com/oauth/token'
 
-		this._authorizer = new Authorizer(options)
+		this._authorizer = new Authorizer({
+			logger: this._log,
+			keyApiHost: options.keyApiHost,
+			publicKey: options.publicKey,
+			keyCacheTTL: options.keyCacheTTL
+		})
 		this._unhandledRejectionHandler = reason => {
 			this._log.exception(reason)
 		}
@@ -88,7 +93,7 @@ module.exports = class SmartApp {
 
 	/**
 	 * Manually set the SmartThings API URL
-	 * @param {String} url
+	 * @param {String} url The host URL
 	 * @default https://api.smartthings.com
 	 * @returns {SmartApp} SmartApp instance
 	 */
@@ -99,7 +104,7 @@ module.exports = class SmartApp {
 
 	/**
 	 * Manually set the refresh token URL
-	 * @param {String} url
+	 * @param {String} url The host URL
 	 * @default https://auth-global.api.smartthings.com/oauth/token
 	 * @returns {SmartApp} SmartApp instance
 	 */
@@ -109,10 +114,21 @@ module.exports = class SmartApp {
 	}
 
 	/**
+	 * Manually set the SmartThings Key API host
+	 * @param {String} url The host URL
+	 * @default https://key.smartthings.com
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	keyApiHost(url) {
+		this._authorizer._keyResolver._httpKeyResolve._keyApiHost = url
+		return this
+	}
+
+	/**
 	 * Set your smartapp automation's client id. Cannot be
 	 * acquired until your app has been created through the
 	 * Developer Workspace.
-	 * @param {String} id
+	 * @param {String} id The clientId
 	 * @returns {SmartApp} SmartApp instance
 	 */
 	clientId(id) {
@@ -125,7 +141,7 @@ module.exports = class SmartApp {
 	 * acquired until your app has been created through the
 	 * Developer Workspace. This secret should never be shared
 	 * or committed into a public repository.
-	 * @param {String} secret
+	 * @param {String} secret The clientSecret
 	 * @returns {SmartApp} SmartApp instance
 	 */
 	clientSecret(secret) {
@@ -195,7 +211,7 @@ module.exports = class SmartApp {
 	/**
 	 * Disable the ability for the user to customize the display name.
 	 *
-	 * @param {Boolean} [value=true]
+	 * @param {Boolean} [value=true] Value
 	 * @default true
 	 * @returns {SmartApp} SmartApp instance
 	 */
@@ -207,7 +223,7 @@ module.exports = class SmartApp {
 	/**
 	 * Disable the ability to remove the app from the configuration flow.
 	 *
-	 * @param {Boolean} [value=true]
+	 * @param {Boolean} [value=true] Value
 	 * @default true
 	 * @returns {SmartApp} SmartApp instance
 	 */
@@ -220,7 +236,7 @@ module.exports = class SmartApp {
 	 * Provide a custom context store used for storing in-flight credentials
 	 * for each installed instance of the app.
 	 *
-	 * @param {*} value
+	 * @param {any} value ContextStore instance
 	 * @example Use the AWS DynamoDB plugin
 	 * smartapp.contextStore(new DynamoDBContextStore('aws-region', 'app-table-name'))
 	 * @example
@@ -307,6 +323,7 @@ module.exports = class SmartApp {
 	 * camelCase identifier, used for i18n keys
 	 * @param {PageCallback} callback Allows you to define config page
 	 * characteristics and access config values
+	 * @returns {SmartApp} SmartApp instance
 	 */
 	page(id, callback) {
 		if (!this._firstPageId) {

--- a/lib/util/authorizer.js
+++ b/lib/util/authorizer.js
@@ -5,12 +5,26 @@ const rp = require('request-promise-native')
 const sshpk = require('sshpk')
 const NodeCache = require('node-cache')
 const httpSignature = require('http-signature')
+const Log = require('./log') // eslint-disable-line no-unused-vars
 
 const invalidPublicKey = 'INVALID'
 const smartthingsKeyApiHost = 'https://key.smartthings.com'
 
+/**
+ * @typedef KeyResolverOptions
+ * @property {Log=} logger Logging utility
+ * @property {String|Object=} publicKey Public key
+ * @property {number} [keyCacheTTL=86400000] Lifetime of key cache in milliseconds. Default 24 hours.
+ * @property {String} [keyApiHost='https://key.smartthings.com'] SmartThings Key API host
+ */
+
 class LocalKeyResolver {
-	constructor(options = {}) {
+	/**
+	 * Creates an instance of LocalKeyResolver.
+	 * @param {KeyResolverOptions} options Override default options
+	 * @memberof LocalKeyResolver
+	 */
+	constructor(options) {
 		this._publicKey = invalidPublicKey
 		if (options.publicKey) {
 			this.setPublicKey(options.publicKey)
@@ -37,7 +51,7 @@ class LocalKeyResolver {
 	 * Get Public Key for specified Key ID.
 	 *
 	 * @param {String} keyId The Key ID as specified on Authorization header.
-	 * @returns {Object} Promise of Public key or null if no key available.
+	 * @returns {Promise.<Object>} Promise of Public key or null if no key available.
 	 */
 	async getKey(keyId) { // eslint-disable-line no-unused-vars
 		return this._publicKey
@@ -45,6 +59,11 @@ class LocalKeyResolver {
 }
 
 class HttpKeyResolver {
+	/**
+	 * Creates an instance of HttpKeyResolver.
+	 * @param {KeyResolverOptions} [options={}] Override default options
+	 * @memberof HttpKeyResolver
+	 */
 	constructor(options = {}) {
 		this._cache = new NodeCache()
 		this._cacheTTL = options.keyCacheTTL || (24 * 60 * 60 * 1000) // 24 hours in millis
@@ -55,7 +74,7 @@ class HttpKeyResolver {
 	 * Get Public Key for specified Key ID.
 	 *
 	 * @param {String} keyId The Key ID as specified on Authorization header.
-	 * @returns {Object} Promise of Public key or null if no key available.
+	 * @returns {Promise.<Object>} Promise of Public key or null if no key available.
 	 */
 	async getKey(keyId) {
 		const cache = this._cache
@@ -93,7 +112,12 @@ class HttpKeyResolver {
 }
 
 class DefaultKeyResolver {
-	constructor(options = {}) {
+	/**
+	 * Creates an instance of DefaultKeyResolver.
+	 * @param {KeyResolverOptions} options Override default options
+	 * @memberof DefaultKeyResolver
+	 */
+	constructor(options) {
 		this._localKeyResolve = new LocalKeyResolver(options)
 		this._httpKeyResolve = new HttpKeyResolver(options)
 	}
@@ -112,7 +136,7 @@ class DefaultKeyResolver {
 	 * Get Public Key for specified Key ID.
 	 *
 	 * @param {String} keyId The Key ID as specified on Authorization header.
-	 * @returns {Object} Promise of Public key or null if no key available.
+	 * @returns {Promise.<Object>} Promise of Public key or null if no key available.
 	 */
 	async getKey(keyId) {
 		if (keyId && keyId.startsWith('/SmartThings')) {
@@ -123,8 +147,16 @@ class DefaultKeyResolver {
 	}
 }
 
+/**
+ * Resolves public keys from available resources
+ */
 module.exports = class Authorizer {
+	/**
+	 * Creates an instance of Authorizer.
+	 * @param {KeyResolverOptions} [options={}] Override default options
+	 */
 	constructor(options = {}) {
+		this._logger = options.logger
 		this._keyResolver = new DefaultKeyResolver(options)
 	}
 
@@ -142,16 +174,24 @@ module.exports = class Authorizer {
 		return this._keyResolver.getKey(keyId)
 	}
 
+	/**
+	 * @param {any} req Incoming request
+	 */
 	async isAuthorized(req) {
-		const keyResolver = this._keyResolver
-		const parsed = httpSignature.parseRequest(req)
-		const publicKey = await keyResolver.getKey(parsed.keyId)
+		try {
+			const keyResolver = this._keyResolver
+			const parsed = httpSignature.parseRequest(req, undefined)
+			const publicKey = await keyResolver.getKey(parsed.keyId)
 
-		if (httpSignature.verifySignature(parsed, publicKey)) {
-			return true
+			if (httpSignature.verifySignature(parsed, publicKey)) {
+				return true
+			}
+
+			this._logger.error('Forbidden - failed verifySignature')
+			return false
+		} catch (error) {
+			this._logger.exception(error)
+			return false
 		}
-
-		console.error('Forbidden - failed verifySignature')
-		return false
 	}
 }

--- a/lib/util/authorizer.js
+++ b/lib/util/authorizer.js
@@ -5,7 +5,7 @@ const rp = require('request-promise-native')
 const sshpk = require('sshpk')
 const NodeCache = require('node-cache')
 const httpSignature = require('http-signature')
-const Log = require('./log') // eslint-disable-line no-unused-vars
+const Log = require('./log')
 
 const invalidPublicKey = 'INVALID'
 const smartthingsKeyApiHost = 'https://key.smartthings.com'
@@ -156,7 +156,7 @@ module.exports = class Authorizer {
 	 * @param {KeyResolverOptions} [options={}] Override default options
 	 */
 	constructor(options = {}) {
-		this._logger = options.logger
+		this._logger = options.logger || new Log()
 		this._keyResolver = new DefaultKeyResolver(options)
 	}
 

--- a/test/functional/device-spec.js
+++ b/test/functional/device-spec.js
@@ -19,7 +19,7 @@ async function fetchContent() {
 	const [profiles, installApp, locations] = await Promise.all([api.deviceProfiles.list(), api.installedApps.list(), api.locations.list()])
 
 	// Generates an access token to be utilized for testing endpoints
-	token = Client.refreshToken('https://auth-global.api.smartthings.com/oauth/token', process.env.CLIENT_ID, process.env.CLIENT_KEY, process.env.REFRESH_TOKEN)
+	const token = Client.refreshToken('https://auth-global.api.smartthings.com/oauth/token', process.env.CLIENT_ID, process.env.CLIENT_KEY, process.env.REFRESH_TOKEN)
 	await token.then(response => {
 		parsedObj = JSON.parse(response.body)
 		accessToken = parsedObj.access_token

--- a/test/unit/boolean-setting-spec.js
+++ b/test/unit/boolean-setting-spec.js
@@ -1,8 +1,8 @@
 /* eslint no-undef: "off" */
 const {expect} = require('chai')
-const Page = require('../lib/pages/page')
-const Section = require('../lib/pages/section')
-const BooleanSetting = require('../lib/pages/boolean-setting')
+const Page = require('../../lib/pages/page')
+const Section = require('../../lib/pages/section')
+const BooleanSetting = require('../../lib/pages/boolean-setting')
 
 describe('boolean-setting', () => {
 	let page = {}

--- a/test/unit/smartapp-context-spec.js
+++ b/test/unit/smartapp-context-spec.js
@@ -1,7 +1,7 @@
 /* eslint no-undef: "off" */
 
 const assert = require('assert').strict
-const SmartApp = require('../lib/smart-app')
+const SmartApp = require('../../lib/smart-app')
 
 class ContextStore {
 	constructor() {


### PR DESCRIPTION
<!-- Describe your pull request. -->
In practice, there were some quirks with using the authorizer class (from both the sdk developer & user perspectives). 

* You can now declare & pass in the options from the root level of the smartapp sdk (`keyHostApi`, `keyCacheTTL`, etc.)
* You can set the `keyHostApi` from the `SmartApp` instance as a chainable function: `keyHostApi('https://key.smartthings.com')`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
