### PR TITLE
feat: Allow API calls while rendering pages in installed app

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -594,6 +594,7 @@ module.exports = class SmartApp {
 						}
 
 						case 'PAGE': {
+							await context.retrieveTokens(this)
 							this._log.event(evt, configurationData.phase)
 							const pageId = configurationData.pageId ? configurationData.pageId : this._firstPageId
 							const pageHandler = this._pages[pageId]

--- a/lib/util/endpoint-context.js
+++ b/lib/util/endpoint-context.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const i18n = require('i18n')
+const {Mutex} = require('async-mutex')
 const SmartThingsApi = require('../api')
 
 module.exports = class EndpointContext {
@@ -97,6 +98,30 @@ module.exports = class EndpointContext {
 			contextStore: app._contextStore,
 			apiMutex
 		})
+	}
+
+	async retrieveTokens(app) {
+		const data = await app._contextStore.get(this.installedAppId)
+		if (data) {
+			this.locationId = data.locationId
+			this.api = new SmartThingsApi({
+				authToken: data.authToken,
+				refreshToken: data.authToken,
+				clientId: app._clientId,
+				clientSecret: app._clientSecret,
+				log: app._log,
+				apiUrl: app._apiUrl,
+				refreshUrl: app._refreshUrl,
+				locationId: this.locationId,
+				installedAppId: this.installedAppId,
+				contextStore: app._contextStore,
+				apiMutex: new Mutex()
+			})
+		}
+	}
+
+	isAuthenticated() {
+		return Boolean(this.api.client.authToken)
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/smartapp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
CONFIGURATION lifecycle events do not include access tokens, even when an app has already been installed. As a result, it is not possible to use data from the API when rendering configuration pages. This change allows such calls provided the app has defined a context store (and therefore has access
tokens available).

The CONFIGURATION lifecycle event should really return access tokens, at least for installed apps, to allow API calls when rendering configuration pages, but in the meantime this change permits such calls by retrieving the tokens (and location ID, which is also missing) from the context store.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
