### PR TITLE
feat: Added default page handler

### DIFF
--- a/doc/pages.md
+++ b/doc/pages.md
@@ -7,13 +7,27 @@
 **page (id, definition)**
 
 ```javascript
-app.page.('pageOne', (page) => {
-    page.nextPageId('pageTwo')
-    ...
+app.page('pageOne', (ctx, page, configData) => {
+    page.section('Heading', section => {
+    	...
+    })
 })
 ```
 Creates a new configuration page. All pages must have an ID, which is used to reference the page in link and next/previous
 fields.
+
+**page (id, definition)**
+
+```javascript
+app.defaultPage((ctx, page, configData) => {
+    if(configData.pageId === 'pageTwo') {
+    	...
+    } else {
+    	...
+    }
+})
+```
+Defines a handler that is called if the page ID doesn't match any of the declared pages.
 
 #### Page Properties
 

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -44,6 +44,20 @@ module.exports = class SmartApp {
 		this._subscribedEventHandlers = {}
 		this._scheduledEventHandlers = {}
 		this._pages = {}
+		this._defaultPage = ((ctx, page, configurationData) => {
+			page.name('System Error!')
+			const msg = configurationData.pageId ?
+				`No handler found for page '${configurationData.pageId}'` :
+				'No page handlers were found'
+
+			page.section('error', section => {
+				section.name('Configuration Page Error')
+				section.paragraphSetting('undefined_handler')
+					.name('Page Handler Missing')
+					.description(msg)
+			})
+			this._log.warn(msg)
+		})
 		this._installedHandler = ((ctx, evt) => {
 			this._updatedHandler(ctx, evt.installData)
 		})
@@ -334,6 +348,19 @@ module.exports = class SmartApp {
 		return this
 	}
 
+	/**
+	 * Define a default handler for pages that don't have specific name-based handlers. Useful for encoding data in
+	 * page name for use in controlling of the rendering of the page from different links
+	 *
+	 * @param {PageCallback} callback Allows you to define config page
+	 * characteristics and access config values
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	defaultPage(callback) {
+		this._defaultPage = callback
+		return this
+	}
+
 	/// ///////////
 	// Install  //
 	/// ///////////
@@ -603,7 +630,9 @@ module.exports = class SmartApp {
 								await pageHandler(context, page, configurationData)
 								responder.respond({statusCode: 200, configurationData: {page: page.toJson()}})
 							} else {
-								throw new Error(`Page '${configurationData.pageId}' not found`)
+								const page = this._localizationEnabled ? new Page(pageId, context.locale) : new Page(pageId)
+								await this._defaultPage(context, page, configurationData)
+								responder.respond({statusCode: 200, configurationData: {page: page.toJson()}})
 							}
 
 							break

--- a/test/unit/smartapp-page-spec.js
+++ b/test/unit/smartapp-page-spec.js
@@ -21,6 +21,13 @@ describe('smartapp-page-spec', () => {
 					.required(true)
 			})
 		})
+		app.defaultPage((ctx, page, config) => {
+			page.section(`Page ${config.pageId}`, section => {
+				section.deviceSetting('contactSensor')
+					.capabilities(['contactSensor'])
+					.required(true)
+			})
+		})
 
 		// Initialize configuration callback
 		app.handleMockCallback({
@@ -53,6 +60,60 @@ describe('smartapp-page-spec', () => {
 			assert.deepStrictEqual(initResponse.configurationData, expectedInitResponse)
 		})
 
+		// Page configuration callback
+		app.handleMockCallback({
+			lifecycle: 'CONFIGURATION',
+			executionId: 'abcf6e72-60f4-1f27-341b-449ad9e2192e',
+			locale: 'en',
+			version: '0.1.0',
+			client: {
+				os: 'ios',
+				version: '0.0.0',
+				language: 'fr'
+			},
+			configurationData: {
+				installedAppId: '702d6539-cde1-4baf-9336-10110a0fd000',
+				phase: 'PAGE',
+				pageId: 'eaAnotherPage',
+				previousPageId: '',
+				config: {}
+			},
+			settings: {}
+		}).then(pageResponse => {
+			const expectedPageResponse = {
+				page: {
+					name: 'pages.eaAnotherPage.name',
+					complete: true,
+					pageId: 'eaAnotherPage',
+					nextPageId: null,
+					previousPageId: null,
+					sections: [
+						{
+							name: 'Page eaAnotherPage',
+							settings: [
+								{
+									id: 'contactSensor',
+									name: 'pages.eaAnotherPage.settings.contactSensor.name',
+									required: true,
+									type: 'DEVICE',
+									description: 'Tap to set',
+									multiple: false,
+									capabilities: [
+										'contactSensor'
+									],
+									permissions: [
+										'r'
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+			assert.deepStrictEqual(pageResponse.configurationData, expectedPageResponse)
+		})
+
+		// Default page handler configuration callback
 		app.handleMockCallback({
 			lifecycle: 'CONFIGURATION',
 			executionId: 'abcf6e72-60f4-1f27-341b-449ad9e2192e',
@@ -155,6 +216,104 @@ describe('smartapp-page-spec', () => {
 				config: {}
 			},
 			settings: {}
+		})
+	})
+
+	it('default page handler', () => {
+		const app = new SmartApp()
+
+		app.handleMockCallback({
+			lifecycle: 'CONFIGURATION',
+			executionId: 'abcf6e72-60f4-1f27-341b-449ad9e2192e',
+			locale: 'en',
+			version: '0.1.0',
+			client: {
+				os: 'ios',
+				version: '0.0.0',
+				language: 'fr'
+			},
+			configurationData: {
+				installedAppId: '702d6539-cde1-4baf-9336-10110a0fd000',
+				phase: 'PAGE',
+				pageId: 'mainPage',
+				previousPageId: '',
+				config: {}
+			},
+			settings: {}
+		}).then(pageResponse => {
+			const expectedPageResponse = {
+				page: {
+					name: 'System Error!',
+					complete: true,
+					pageId: 'mainPage',
+					nextPageId: null,
+					previousPageId: null,
+					sections: [
+						{
+							name: 'Configuration Page Error',
+							settings: [
+								{
+									id: 'undefined_handler',
+									required: false,
+									name: 'Page Handler Missing',
+									type: 'PARAGRAPH',
+									description: 'No handler found for page \'mainPage\''
+								}
+							]
+						}
+					]
+				}
+			}
+			assert.deepStrictEqual(pageResponse.configurationData, expectedPageResponse)
+		})
+	})
+
+	it('default page handler without pageId', () => {
+		const app = new SmartApp()
+
+		app.handleMockCallback({
+			lifecycle: 'CONFIGURATION',
+			executionId: 'abcf6e72-60f4-1f27-341b-449ad9e2192e',
+			locale: 'en',
+			version: '0.1.0',
+			client: {
+				os: 'ios',
+				version: '0.0.0',
+				language: 'fr'
+			},
+			configurationData: {
+				installedAppId: '702d6539-cde1-4baf-9336-10110a0fd000',
+				phase: 'PAGE',
+				pageId: '',
+				previousPageId: '',
+				config: {}
+			},
+			settings: {}
+		}).then(pageResponse => {
+			const expectedPageResponse = {
+				page: {
+					name: 'System Error!',
+					complete: true,
+					pageId: undefined,
+					nextPageId: null,
+					previousPageId: null,
+					sections: [
+						{
+							name: 'Configuration Page Error',
+							settings: [
+								{
+									id: 'undefined_handler',
+									required: false,
+									name: 'Page Handler Missing',
+									type: 'PARAGRAPH',
+									description: 'No page handlers were found'
+								}
+							]
+						}
+					]
+				}
+			}
+			assert.deepStrictEqual(pageResponse.configurationData, expectedPageResponse)
 		})
 	})
 })


### PR DESCRIPTION
Closes #98 

Added option to define a default page handler that is called when the pageId of a configuration/page lifecycle event does not match any of the declared pages. This feature is useful for allowing information to be encoded in pageIds in links, to render pages differently depending on which link was used to display them. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
