### PR TITLE
fix: removed resolveWithFull response that is a breaking change

### DIFF
--- a/lib/platform/client.js
+++ b/lib/platform/client.js
@@ -30,7 +30,6 @@ class Client {
 			url: `${this.apiUrl}/${path}`,
 			method: method ? method : 'GET',
 			json: true,
-			resolveWithFullResponse: true,
 			headers: {
 				'Content-Type': 'application/json; charset=utf-8',
 				Authorization: 'Bearer ' + this.authToken


### PR DESCRIPTION
The change that added `resolveWithFullResponse: true` to the API client is a breaking change for anyone who is relying on API responses. Instead of returning the JSON body the calls now return an IncomingMessage object with a `body` property. Pushing a hotfix for this issue immediately to unbreak things. We can sort out the functional tests at a later time

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
