### PR TITLE
fix: Bug in configuration/page retrieveTokens when no ctx store

### DIFF
--- a/lib/util/endpoint-context.js
+++ b/lib/util/endpoint-context.js
@@ -101,22 +101,24 @@ module.exports = class EndpointContext {
 	}
 
 	async retrieveTokens(app) {
-		const data = await app._contextStore.get(this.installedAppId)
-		if (data) {
-			this.locationId = data.locationId
-			this.api = new SmartThingsApi({
-				authToken: data.authToken,
-				refreshToken: data.authToken,
-				clientId: app._clientId,
-				clientSecret: app._clientSecret,
-				log: app._log,
-				apiUrl: app._apiUrl,
-				refreshUrl: app._refreshUrl,
-				locationId: this.locationId,
-				installedAppId: this.installedAppId,
-				contextStore: app._contextStore,
-				apiMutex: new Mutex()
-			})
+		if (app._contextStore) {
+			const data = await app._contextStore.get(this.installedAppId)
+			if (data) {
+				this.locationId = data.locationId
+				this.api = new SmartThingsApi({
+					authToken: data.authToken,
+					refreshToken: data.authToken,
+					clientId: app._clientId,
+					clientSecret: app._clientSecret,
+					log: app._log,
+					apiUrl: app._apiUrl,
+					refreshUrl: app._refreshUrl,
+					locationId: this.locationId,
+					installedAppId: this.installedAppId,
+					contextStore: app._contextStore,
+					apiMutex: new Mutex()
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
Hotfix to correct bug introduced with config page token change when there is not context store.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
