### PR TITLE
feat: corrected handlers for non-device event types

### DIFF
--- a/lib/platform/client.js
+++ b/lib/platform/client.js
@@ -32,7 +32,7 @@ class Client {
 			json: true,
 			headers: {
 				'Content-Type': 'application/json; charset=utf-8',
-				Authorization: 'Bearer ' + this.authToken
+				'Authorization': 'Bearer ' + this.authToken
 			}
 		}
 		if (data) {
@@ -61,7 +61,7 @@ class Client {
 			json: true,
 			headers: {
 				'Content-Type': 'application/json; charset=utf-8',
-				Authorization: 'Bearer ' + this.authToken
+				'Authorization': 'Bearer ' + this.authToken
 			}
 		}
 		if (data) {
@@ -128,7 +128,7 @@ exports.refreshToken = function (url, clientId, clientSecret, refreshToken) {
 		resolveWithFullResponse: true,
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
-			Authorization: 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`, 'ascii').toString('base64')
+			'Authorization': 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`, 'ascii').toString('base64')
 		},
 		body: `grant_type=refresh_token&client_id=${clientId}&client_secret=${clientSecret}&refresh_token=${refreshToken}`
 	}

--- a/lib/platform/subscriptions.js
+++ b/lib/platform/subscriptions.js
@@ -74,24 +74,24 @@ module.exports = class Subscriptions extends Base {
 	}
 
 	// TODO there's no handler name!
-	subscribeToModeChange(_) {
+	subscribeToModeChange(subscriptionName) {
 		const path = `installedapps/${this.st.installedAppId}/subscriptions`
 		const body = {
 			sourceType: 'MODE',
 			mode: {
-				locationId: this.st.locationId
+				locationId: this.st.locationId,
+				subscriptionName
 			}
 		}
 		return this.st.client.request(path, 'POST', body)
 	}
 
 	// TODO -- need this for entire location
-	subscribeToDeviceLifecycle(devices, subscriptionName) {
+	subscribeToDeviceLifecycle(subscriptionName) {
 		const path = `installedapps/${this.st.installedAppId}/subscriptions`
 		const body = {
 			sourceType: 'DEVICE_LIFECYCLE',
 			deviceLifecycle: {
-				deviceIds: devices.map(it => it.deviceConfig.deviceId),
 				locationId: this.st.locationId,
 				subscriptionName
 			}
@@ -100,12 +100,11 @@ module.exports = class Subscriptions extends Base {
 	}
 
 	// Why does this accept an array of device IDs but devices does not
-	subscribeToDeviceHealth(devices, subscriptionName) {
+	subscribeToDeviceHealth(subscriptionName) {
 		const path = `installedapps/${this.st.installedAppId}/subscriptions`
 		const body = {
 			sourceType: 'DEVICE_HEALTH',
 			deviceHealth: {
-				deviceIds: devices.map(it => it.deviceConfig.deviceId),
 				locationId: this.st.locationId,
 				subscriptionName
 			}

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -9,6 +9,7 @@ const responders = require('./util/responders')
 const Page = require('./pages/page')
 const EndpointContext = require('./util/endpoint-context')
 const Log = require('./util/log')
+const ConfigurationError = require('./util/configuration-error')
 
 module.exports = class SmartApp {
 	/**
@@ -42,6 +43,7 @@ module.exports = class SmartApp {
 		this._disableCustomDisplayName = options.disableCustomDisplayName === undefined ? false : options.disableCustomDisplayName
 		this._disableRemoveApp = options.disableRemoveApp === undefined ? false : options.disableRemoveApp
 		this._subscribedEventHandlers = {}
+		this._eventTypeHandlers = {}
 		this._scheduledEventHandlers = {}
 		this._pages = {}
 		this._defaultPage = ((ctx, page, configurationData) => {
@@ -442,7 +444,26 @@ module.exports = class SmartApp {
 	 * @param {EventCallback} callback Callback handler object
 	 * @returns {SmartApp} SmartApp instance
 	 */
-	subscribedEventHandler(name, callback) {
+	/**
+	 * Handler for named subscriptions to events
+	 *
+	 * @param {String} name Provide the name matching a created subscription
+	 * @param {EventCallback} callback Callback handler object
+	 * @param {String} eventType the type of event. No need to specify for DEVICE and CAPABILITY event types.
+	 * Needed primarily because other event types do not include the subscription name. As a result, there can only
+	 * be one handler for any of these event types. Value is one of DEVICE_LIFECYCLE, DEVICE_HEALTH, SECURITY_ARM_STATE
+	 * HUB_HEALTH, and SCENE_LIFECYCLE.
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	subscribedEventHandler(name, callback, eventType = undefined) {
+		if (eventType) {
+			if (this._eventTypeHandlers[eventType] && this._eventTypeHandlers[eventType] !== name) {
+				throw new ConfigurationError(`Event type ${eventType} already assigned to handler ${this._eventTypeHandlers[eventType]}`)
+			}
+
+			this._eventTypeHandlers[eventType] = name
+		}
+
 		this._subscribedEventHandlers[name] = callback
 		return this
 	}
@@ -744,18 +765,41 @@ module.exports = class SmartApp {
 								break
 							}
 
+							case 'DEVICE_LIFECYCLE_EVENT': {
+								// TODO - remove when handler name is returned in event
+								const handlerName = this._eventTypeHandlers[event.eventType]
+								const handler = this._subscribedEventHandlers[handlerName]
+								results.push(handler(context, event.deviceLifecycleEvent))
+								break
+							}
+
+							case 'DEVICE_HEALTH_EVENT': {
+								// TODO - remove when handler name is returned in event
+								const handlerName = this._eventTypeHandlers[event.eventType]
+								const handler = this._subscribedEventHandlers[handlerName]
+								results.push(handler(context, event.deviceHealthEvent))
+								break
+							}
+
+							case 'HUB_HEALTH_EVENT': {
+								// TODO - remove when handler name is returned in event
+								const handlerName = this._eventTypeHandlers[event.eventType]
+								const handler = this._subscribedEventHandlers[handlerName]
+								results.push(handler(context, event.hubHealthEvent))
+								break
+							}
+
 							case 'MODE_EVENT': {
-								// TODO - there is no mode handler name!!!
-								const handlerName = 'modeChangeHandler'
+								// TODO - remove when handler name is returned in event
+								const handlerName = this._eventTypeHandlers[event.eventType]
 								const handler = this._subscribedEventHandlers[handlerName]
 								results.push(handler(context, event.modeEvent))
 								break
 							}
 
 							case 'SECURITY_ARM_STATE_EVENT': {
-								// TODO - name specified but not returned!!!
-								// const handlerName = event.securityArmStateEvent.name;
-								const handlerName = 'securityArmStateHandler'
+								// TODO - remove when handler name is returned in event
+								const handlerName = this._eventTypeHandlers[event.eventType]
 								const handler = this._subscribedEventHandlers[handlerName]
 								results.push(handler(context, event.securityArmStateEvent))
 								break

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -541,7 +541,7 @@ module.exports = class SmartApp {
 	 * @param {String} [eventType=undefined] The type of event
 	 * @returns {SmartApp} SmartApp instance
 	 */
-	_subscribedEventHandler(name, callback, eventType = undefined) {
+	subscribedEventHandler(name, callback, eventType = undefined) {
 		if (eventType) {
 			if (this._eventTypeHandlers[eventType] && this._eventTypeHandlers[eventType] !== name) {
 				throw new ConfigurationError(`Event type ${eventType} already assigned to handler ${this._eventTypeHandlers[eventType]}`)
@@ -562,7 +562,7 @@ module.exports = class SmartApp {
 	 */
 	subscribedModeEventHandler(name, callback) {
 		const eventType = 'MODE_EVENT'
-		this._subscribedEventHandler(name, callback, eventType)
+		this.subscribedEventHandler(name, callback, eventType)
 		return this
 	}
 
@@ -573,7 +573,7 @@ module.exports = class SmartApp {
 	 */
 	subscribedDeviceEventHandler(name, callback) {
 		const eventType = 'DEVICE_EVENT'
-		this._subscribedEventHandler(name, callback, eventType)
+		this.subscribedEventHandler(name, callback, eventType)
 		return this
 	}
 
@@ -584,7 +584,7 @@ module.exports = class SmartApp {
 	 */
 	subscribedTimerEventHandler(name, callback) {
 		const eventType = 'TIMER_EVENT'
-		this._subscribedEventHandler(name, callback, eventType)
+		this.subscribedEventHandler(name, callback, eventType)
 		return this
 	}
 
@@ -595,7 +595,7 @@ module.exports = class SmartApp {
 	 */
 	subscribedHubHealthEventHandler(name, callback) {
 		const eventType = 'HUB_HEALTH_EVENT'
-		this._subscribedEventHandler(name, callback, eventType)
+		this.subscribedEventHandler(name, callback, eventType)
 		return this
 	}
 
@@ -606,7 +606,7 @@ module.exports = class SmartApp {
 	 */
 	subscribedDeviceLifecycleEventHandler(name, callback) {
 		const eventType = 'DEVICE_LIFECYCLE_EVENT'
-		this._subscribedEventHandler(name, callback, eventType)
+		this.subscribedEventHandler(name, callback, eventType)
 		return this
 	}
 
@@ -617,7 +617,7 @@ module.exports = class SmartApp {
 	 */
 	subscribedDeviceHealthEventHandler(name, callback) {
 		const eventType = 'DEVICE_HEALTH_EVENT'
-		this._subscribedEventHandler(name, callback, eventType)
+		this.subscribedEventHandler(name, callback, eventType)
 		return this
 	}
 
@@ -628,7 +628,7 @@ module.exports = class SmartApp {
 	 */
 	subscribedSecurityArmStateEventHandler(name, callback) {
 		const eventType = 'SECURITY_ARM_STATE_EVENT'
-		this._subscribedEventHandler(name, callback, eventType)
+		this.subscribedEventHandler(name, callback, eventType)
 		return this
 	}
 

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -555,6 +555,84 @@ module.exports = class SmartApp {
 	}
 
 	/**
+	 * Mode event handler. Only one can be used at a time.
+	 * @param {String} name Subscription name
+	 * @param {ModeEventCallback} callback `MODE_EVENT` callback
+	 * @returns {SmartApp} instance
+	 */
+	subscribedModeEventHandler(name, callback) {
+		const eventType = 'MODE_EVENT'
+		this._subscribedEventHandler(name, callback, eventType)
+		return this
+	}
+
+	/**
+	 * Device event handler. Only one can be used at a time.
+	 * @param {String} name
+	 * @param {DeviceEventCallback} callback
+	 */
+	subscribedDeviceEventHandler(name, callback) {
+		const eventType = 'DEVICE_EVENT'
+		this._subscribedEventHandler(name, callback, eventType)
+		return this
+	}
+
+	/**
+	 * Timer event handler. Only one can be used at a time.
+	 * @param {String} name
+	 * @param {TimerEventCallback} callback
+	 */
+	subscribedTimerEventHandler(name, callback) {
+		const eventType = 'TIMER_EVENT'
+		this._subscribedEventHandler(name, callback, eventType)
+		return this
+	}
+
+	/**
+	 * Hub health event handler. Only one can be used at a time.
+	 * @param {String} name
+	 * @param {HubHealthEventCallback} callback
+	 */
+	subscribedHubHealthEventHandler(name, callback) {
+		const eventType = 'HUB_HEALTH_EVENT'
+		this._subscribedEventHandler(name, callback, eventType)
+		return this
+	}
+
+	/**
+	 * Device lifecycle event handler. Only one can be used at a time.
+	 * @param {String} name
+	 * @param {DeviceLifecycleEventCallback} callback
+	 */
+	subscribedDeviceLifecycleEventHandler(name, callback) {
+		const eventType = 'DEVICE_LIFECYCLE_EVENT'
+		this._subscribedEventHandler(name, callback, eventType)
+		return this
+	}
+
+	/**
+	 * Device health event handler. Only one can be used at a time.
+	 * @param {String} name
+	 * @param {DeviceHealthEventCallback} callback
+	 */
+	subscribedDeviceHealthEventHandler(name, callback) {
+		const eventType = 'DEVICE_HEALTH_EVENT'
+		this._subscribedEventHandler(name, callback, eventType)
+		return this
+	}
+
+	/**
+	 * Security arm state event handler. Only one can be used at a time.
+	 * @param {String} name
+	 * @param {SecurityArmStateEventCallback} callback
+	 */
+	subscribedSecurityArmStateEventHandler(name, callback) {
+		const eventType = 'SECURITY_ARM_STATE_EVENT'
+		this._subscribedEventHandler(name, callback, eventType)
+		return this
+	}
+
+	/**
 	 * Handler for named subscriptions to **scheduled** events
 	 *
 	 * @param {String} name Provide the name matching a created subscription

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -400,10 +400,71 @@ module.exports = class SmartApp {
 	}
 
 	/**
+	 * @typedef SimpleValue A simple value
+	 * @property {('NULL_VALUE'|'INT_VALUE'|'DOUBLE_VALUE'|'STRING_VALUE'|'BOOLEAN_VALUE')} valueType The type of the value.
+	 * @property {number=} intValue
+	 * @property {number=} doubleValue
+	 * @property {String} stringValue
+	 * @property {Boolean} boolValue
+	 */
+
+	/**
+	 * @typedef {Object} SecurityArmStateEvent
+	 * @property {String} eventId The id of the event
+	 * @property {String} locationId The id of the location in which the event was triggered.
+	 * @property {('UNKNOWN'|'ARMED_STAY'|'ARMED_AWAY'|'DISARMED')} armState The arm state of a security statem.
+	 * @property {SimpleValue} optionalArguments A set of key / value pairs useful for passing any optional arguments
+	 */
+	/**
 	 * @typedef {Object} ModeEvent
 	 * @property {String} eventId The id of the event
 	 * @property {String} locationId The id of the location in which the event was triggered.
 	 * @property {String} modeId The ID of the mode associated with a MODE_EVENT.
+	 */
+
+	/**
+	 * @typedef HubHealthEvent
+	 * @property {String} eventId The id of the event.
+	 * @property {String} locationId The id of the location in which the event was triggered.
+	 * @property {String} hubId The id of the hub.
+	 * @property {('OFFLINE'|'ONLINE'|'ZWAVE_OFFLINE'|'ZWAVE_ONLINE'|'ZIGBEE_OFFLINE'|'ZIGBEE_ONLINE'|'BLUETOOTH_OFFLINE'|'BLUETOOTH_ONLINE')} status The status of the hub.
+	 * @property {('NONE'|'DISCONNECTED'|'INACTIVE')} reason The reason the hub is offline.
+	 */
+
+	/**
+	 * @typedef DeviceHealthEvent
+	 * @property {String} eventId The id of the event.
+	 * @property {String} locationId The id of the location in which the event was triggered.
+	 * @property {String} deviceId The id of the device.
+	 * @property {String} hubId The id of the hub.
+	 * @property {('OFFLINE'|'ONLINE'|'UNHEALTHY')} status The status of the device.
+	 * @property {('NONE'|'SERVICE_UNAVAILABLE'|'HUB_OFFLINE'|'ZWAVE_OFFLINE'|'ZIGBEE_OFFLINE'|'BLUETOOTH_OFFLINE'|'HUB_DISCONNECTED')} reason The reason the device is offline.
+	 */
+
+	/**
+	 * @typedef DeviceLifecycleMove Move device lifecycle
+	 * @property {String} locationId
+	 */
+
+	/**
+	 * @typedef {Object} DeviceLifecycleEvent An event on a device that matched a subscription for this app.
+	 * @property {('CREATE'|'DELETE'|'UPDATE'|'MOVE_FROM'|'MOVE_TO')} lifecycle
+	  * The device lifecycle. The lifecycle will be one of:
+      *  - **`CREATE`** - Invoked when a device is created.
+      *  - **`DELETE`**  - Invoked when a device is deleted.
+      *  - **`UPDATE`**  - Invoked when a device is updated.
+      *  - **`MOVE_FROM`**  - Invoked when a device is moved from a location.
+      *  - **`MOVE_TO`**  - Invoked when a device is moved to a location.
+	 * @property {String} eventId The ID of the event.
+	 * @property {String} locationId The ID of the location in which the event was triggered.
+	 * @property {String} deviceId The ID of the location in which the event was triggered.
+	 * @property {String} deviceName The name of the device.
+	 * @property {String} principal The principal that made the change
+	 * @property {Object} create Invoked when a device is created.
+	 * @property {Object} delete Invoked when a device is deleted.
+	 * @property {Object} update Invoked when a device is updated.
+	 * @property {DeviceLifecycleMove} moveFrom Invoked when a device is moved from a location.
+	 * @property {DeviceLifecycleMove} moveTo Invoked when a device is moved to a location.
 	 */
 
 	/**
@@ -431,31 +492,56 @@ module.exports = class SmartApp {
 	 */
 
 	/**
-	 * @callback EventCallback
+	 * @callback ModeEventCallback
 	 * @param context { import('./util/endpoint-context') }
-	 * @param {ModeEvent|DeviceEvent|TimerEvent} event
-	 * @returns {EventCallback}
+	 * @param {ModeEvent} modeEvent
 	 */
 
 	/**
-	 * Handler for named subscriptions to events
-	 *
-	 * @param {String} name Provide the name matching a created subscription
-	 * @param {EventCallback} callback Callback handler object
-	 * @returns {SmartApp} SmartApp instance
+	 * @callback DeviceEventCallback
+	 * @param context { import('./util/endpoint-context') }
+	 * @param {DeviceEvent} deviceEvent
 	 */
+
 	/**
-	 * Handler for named subscriptions to events
+	 * @callback TimerEventCallback
+	 * @param context { import('./util/endpoint-context') }
+	 * @param {TimerEvent} timerEvent
+	 */
+
+	/**
+	 * @callback HubHealthEventCallback
+	 * @param context { import('./util/endpoint-context') }
+	 * @param {HubHealthEvent} hubHealthEvent
+	 */
+
+	/**
+	 * @callback DeviceHealthEventCallback
+	 * @param context { import('./util/endpoint-context') }
+	 * @param {DeviceHealthEvent} deviceHealthEvent
+	 */
+
+	/**
+	 * @callback DeviceLifecycleEventCallback
+	 * @param context { import('./util/endpoint-context') }
+	 * @param {DeviceLifecycleEvent} deviceLifecycleEvent
+	 */
+
+	/**
+	 * @callback SecurityArmStateEventCallback
+	 * @param context { import('./util/endpoint-context') }
+	 * @param {SecurityArmStateEvent} securityArmStateEvent
+	 */
+
+	/**
+	 * Internal handler for named subscriptions to events
 	 *
 	 * @param {String} name Provide the name matching a created subscription
-	 * @param {EventCallback} callback Callback handler object
-	 * @param {String} eventType the type of event. No need to specify for DEVICE and CAPABILITY event types.
-	 * Needed primarily because other event types do not include the subscription name. As a result, there can only
-	 * be one handler for any of these event types. Value is one of DEVICE_LIFECYCLE, DEVICE_HEALTH, SECURITY_ARM_STATE
-	 * HUB_HEALTH, and SCENE_LIFECYCLE.
+	 * @param {*} callback Callback handler object
+	 * @param {String} [eventType=undefined] The type of event
 	 * @returns {SmartApp} SmartApp instance
 	 */
-	subscribedEventHandler(name, callback, eventType = undefined) {
+	_subscribedEventHandler(name, callback, eventType = undefined) {
 		if (eventType) {
 			if (this._eventTypeHandlers[eventType] && this._eventTypeHandlers[eventType] !== name) {
 				throw new ConfigurationError(`Event type ${eventType} already assigned to handler ${this._eventTypeHandlers[eventType]}`)

--- a/lib/util/configuration-error.js
+++ b/lib/util/configuration-error.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = class ConfigurationError {
+	constructor(message) {
+		this.message = message
+	}
+
+	toString() {
+		return this.message
+	}
+}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
       "no-useless-constructor": 1,
       "promise/prefer-await-to-then": 1,
       "prefer-object-spread": 1,
-      "no-template-curly-in-string": 0
+      "no-template-curly-in-string": 0,
+      "quote-props": ["error", "consistent"]
     },
     "overrides": [
       {

--- a/test/unit/event-type-handler-spec.js
+++ b/test/unit/event-type-handler-spec.js
@@ -1,0 +1,210 @@
+/* eslint no-undef: 'off' */
+const assert = require('assert').strict
+const SmartApp = require('../../lib/smart-app')
+
+describe('event-type-handler-spec', () => {
+	let app
+	let receivedEvent
+
+	beforeEach(() => {
+		app = new SmartApp()
+	})
+
+	it('should handle MODE_EVENT', () => {
+		app.subscribedEventHandler('modeHandler', (_, event) => {
+			receivedEvent = event
+		}, 'MODE_EVENT')
+		app.handleMockCallback({
+			'lifecycle': 'EVENT',
+			'executionId': '66D91548-8643-444F-B402-F5CE832A5120',
+			'locale': 'en-US',
+			'version': '0.1.0',
+			'eventData': {
+				'authToken': 'WVlMWZjNThkNSIsInNjb3BlIjpbImk6ZGV2aWNlcHJvZmlsZXMiLCJyOmRldmljZXM6KiIsInI6bG9jYXRpb25zOioiLCJ4OmRldmljZXM6KiJdLCJleHAiOjE1NjM5NTI0NDEsImNsaWVudF9pZCI6ImVhODM5ZGJhLTVkZGEtNDFmYS1iMGU0LTgzOWYyOTRiNjJhMiJ9.mJ3cHGncbk6BCt-eEHOb-w3_F6RB_O2A48MzgCphfnOIHkF8WDoDPW-Hhu6c40kXGpGVAryQDHrNWB5NauYVztuYxHBrjFVpxgFDcVOd1zZjUbba4Aeflde8Q0cfPHWezJB3udsXCbRxO0BOXArQmWL_orVb1SX4U-A59anHOQ-x8zvKEYB_-swFSMF3bL2Sbz7-tCKREzMoWWXvJ5mVdek_QBQE0kHLYH0i-GOiKKNjTz2w8RrCOI9FR70cuSWyqG47Q5EtF7ESAHjIVmqtQcnuchK2zhhWnrJbicJ_XzvtPrJs1DBKzJUkNAsgR4RAA6GpixQZLnCrIw0HJU7oRA',
+				'installedApp': {
+					'installedAppId': 'a7dfaa78-cce7-459c-8d0c-d593f0d55b76',
+					'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+					'config': {},
+					'permissions': [
+						'r:locations:*',
+						'x:devices:*',
+						'i:deviceprofiles',
+						'r:devices:*'
+					]
+				},
+				'events': [
+					{
+						'eventTime': '2019-07-24T07:09:01Z',
+						'eventType': 'MODE_EVENT',
+						'modeEvent': {
+							'eventId': 'e9ede6a6-ade1-11e9-8a15-5998645d79ea',
+							'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+							'modeId': '57ae8db9-9187-4293-bf7c-c0218825e94e'
+						}
+					}
+				]
+			},
+			'settings': {}
+		})
+		assert.equal(receivedEvent.eventId, 'e9ede6a6-ade1-11e9-8a15-5998645d79ea')
+		assert.equal(receivedEvent.locationId, '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5')
+		assert.equal(receivedEvent.modeId, '57ae8db9-9187-4293-bf7c-c0218825e94e')
+	})
+
+	it('should handle DEVICE_LIFECYCLE_EVENT', () => {
+		app.subscribedEventHandler('deviceLifecycle', (_, event) => {
+			receivedEvent = event
+		}, 'DEVICE_LIFECYCLE_EVENT')
+		app.handleMockCallback({
+			'lifecycle': 'EVENT',
+			'executionId': '6b85d1aa-a059-fe2f-ac71-f863df37da65',
+			'locale': 'en-US',
+			'version': '0.1.0',
+			'eventData': {
+				'authToken': 'IjoiUlMyNTYifQ.eyJwcmluY2lwYWwiOiJpbnN0YWxsZWRhcHA6YTdkZmFhNzgtY2NlNy00NTljLThkMGMtZDU5M2YwZDU1Yjc2OjVmMjc4YmFhLWFmZjAtNGNmMC1hMzIzLTNkOWVlMWZjNThkNSIsInNjb3BlIjpbImk6ZGV2aWNlcHJvZmlsZXMiLCJyOmRldmljZXM6KiIsInI6bG9jYXRpb25zOioiLCJ4OmRldmljZXM6KiJdLCJleHAiOjE1NjM5NTI5MjMsImNsaWVudF9pZCI6ImVhODM5ZGJhLTVkZGEtNDFmYS1iMGU0LTgzOWYyOTRiNjJhMiJ9.FOZFZCBMMG-kMmRK8y_QDeA4722GuXEb86sKgDBeJN2WrizJr6Id8XKMvJAP9dR_yMzc4FlykZ0ln51YrLQ6DIUlzHuKL28dSU_RkJhkIMqTx8XxSOe7ae2nRaMdhtMnjx6t9NaxTMNkSFGYCG_McwHTHPGTDu0AxONHTzOjqECyYfSXR7BASkQqaDca0hbyfp0kqRnb_9HBdnE7gHYgwAMij_co2yGeBD4aMPIbr04OJSJsJZ89jfJ17CX6hsKKRkMwicauIQKzxgJnLLORuRX8amc_2fLEgbJSz1YKpJgSNLs555Kb3B31OU9LuqtsbNBTYg9MT9xnS4C90nNdFw',
+				'installedApp': {
+					'installedAppId': 'a7dfaa78-cce7-459c-8d0c-d593f0d55b76',
+					'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+					'config': {},
+					'permissions': [
+						'r:locations:*',
+						'x:devices:*',
+						'i:deviceprofiles',
+						'r:devices:*'
+					]
+				},
+				'events': [
+					{
+						'eventTime': '2019-07-24T07:17:03Z',
+						'eventType': 'DEVICE_LIFECYCLE_EVENT',
+						'deviceLifecycleEvent': {
+							'lifecycle': 'UPDATE',
+							'eventId': '091bd080-ade3-11e9-aa79-415d41e7ce77',
+							'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+							'deviceId': 'ba0767c3-f883-438d-9db1-b1a84b8d347b',
+							'deviceName': '',
+							'principal': '',
+							'update': {}
+						}
+					}
+				]
+			},
+			'settings': {}
+		})
+		assert.equal(receivedEvent.eventId, '091bd080-ade3-11e9-aa79-415d41e7ce77')
+	})
+
+	it('should handle DEVICE_HEALTH_EVENT', () => {
+		app.subscribedEventHandler('deviceHealthHandler', (_, event) => {
+			receivedEvent = event
+		}, 'DEVICE_HEALTH_EVENT')
+		app.handleMockCallback({
+			'lifecycle': 'EVENT',
+			'executionId': '66b5208f-f3e2-403a-b2da-e2e34e009828',
+			'locale': 'en-US',
+			'version': '0.1.0',
+			'eventData': {
+				'authToken': 'LdnBwVkFNNTYtOFIwX21BIiwiYWxnIjoiUlMyNTYifQ.eyJwcmluY2lwYWwiOiJpbnN0YWxsZWRhcHA6YTdkZmFhNzgtY2NlNy00NTljLThkMGMtZDU5M2YwZDU1Yjc2OjVmMjc4YmFhLWFmZjAtNGNmMC1hMzIzLTNkOWVlMWZjNThkNSIsInNjb3BlIjpbImk6ZGV2aWNlcHJvZmlsZXMiLCJyOmRldmljZXM6KiIsInI6bG9jYXRpb25zOioiLCJ4OmRldmljZXM6KiJdLCJleHAiOjE1NjM5NTMzNTcsImNsaWVudF9pZCI6ImVhODM5ZGJhLTVkZGEtNDFmYS1iMGU0LTgzOWYyOTRiNjJhMiJ9.AJxVO9dlboeuRUBPbUKmaZ2IXYVDYkN5E4Usq6V3vuhPWcl57R5hkEmnREkjwih5FoxhRxbTvQotrm18K9Z-zTIHd9oOH2_pYsyWyaQIa_nPRlYxmu6s6gBM4uxHklS0Ez43bFSbUYMD9jSBPjbujnTPL1WUqF_x5o-zhXCwNXUN-yQ84pkHuuFCilNNCEqj5WTPFW-OxId4VDk3kx3snrk6w2bJzgbJ3G97v1EgXXMmbqGuzW0qwJNYv9jcCQTlE4WEsfsnyNmEmkzMGNls0e79v-0C_X0ES5EszoP6zNA7xPS0BOdZvWWDTfSILtTlnh6uJ7KOMulncqGZkl9ShQ',
+				'installedApp': {
+					'installedAppId': 'a7dfaa78-cce7-459c-8d0c-d593f0d55b76',
+					'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+					'config': {},
+					'permissions': [
+						'r:locations:*',
+						'x:devices:*',
+						'i:deviceprofiles',
+						'r:devices:*'
+					]
+				},
+				'events': [
+					{
+						'eventTime': '2019-07-24T07:24:17Z',
+						'eventType': 'DEVICE_HEALTH_EVENT',
+						'deviceHealthEvent': {
+							'eventId': '0bde7df0-ade4-11e9-b187-3f8238130d63',
+							'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+							'deviceId': '1ed46054-c643-4153-b50d-7509de9b237b',
+							'hubId': '',
+							'status': 'OFFLINE',
+							'reason': 'SERVICE_UNAVAILABLE'
+						}
+					}
+				]
+			},
+			'settings': {}
+		})
+		assert.equal(receivedEvent.eventId, '0bde7df0-ade4-11e9-b187-3f8238130d63')
+	})
+
+	it('should handle HUB_HEALTH_EVENT', () => {
+		app.subscribedEventHandler('hubHealthHandler', (_, event) => {
+			receivedEvent = event
+		}, 'HUB_HEALTH_EVENT')
+		app.handleMockCallback({
+			'lifecycle': 'EVENT',
+			'executionId': '66b5208f-f3e2-403a-b2da-e2e34e009828',
+			'locale': 'en-US',
+			'version': '0.1.0',
+			'eventData': {
+				'installedApp': {
+					'installedAppId': 'a7dfaa78-cce7-459c-8d0c-d593f0d55b76',
+					'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+					'config': {},
+					'permissions': [
+						'r:locations:*',
+						'x:devices:*',
+						'i:deviceprofiles',
+						'r:devices:*'
+					]
+				},
+				'events': [
+					{
+						'eventTime': '2019-07-24T07:24:17Z',
+						'eventType': 'HUB_HEALTH_EVENT',
+						'hubHealthEvent': {
+							'eventId': '12347df0-ade4-11e9-b187-3f8238130d63'
+						}
+					}
+				]
+			},
+			'settings': {}
+		})
+		assert.equal(receivedEvent.eventId, '12347df0-ade4-11e9-b187-3f8238130d63')
+	})
+
+	it('should handle SECURITY_ARM_STATE_EVENT', () => {
+		app.subscribedEventHandler('hubHealthHandler', (_, event) => {
+			receivedEvent = event
+		}, 'SECURITY_ARM_STATE_EVENT')
+		app.handleMockCallback({
+			'lifecycle': 'EVENT',
+			'executionId': '66b5208f-f3e2-403a-b2da-e2e34e009828',
+			'locale': 'en-US',
+			'version': '0.1.0',
+			'eventData': {
+				'installedApp': {
+					'installedAppId': 'a7dfaa78-cce7-459c-8d0c-d593f0d55b76',
+					'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+					'config': {},
+					'permissions': [
+						'r:locations:*',
+						'x:devices:*',
+						'i:deviceprofiles',
+						'r:devices:*'
+					]
+				},
+				'events': [
+					{
+						'eventTime': '2019-07-24T07:24:17Z',
+						'eventType': 'SECURITY_ARM_STATE_EVENT',
+						'securityArmStateEvent': {
+							'eventId': '12347df0-ade4-11e9-b187-3f8238130d63'
+						}
+					}
+				]
+			},
+			'settings': {}
+		})
+		assert.equal(receivedEvent.eventId, '12347df0-ade4-11e9-b187-3f8238130d63')
+	})
+})

--- a/test/unit/event-type-handler-spec.js
+++ b/test/unit/event-type-handler-spec.js
@@ -12,9 +12,14 @@ describe('event-type-handler-spec', () => {
 	})
 
 	it('should handle MODE_EVENT', () => {
-		app.subscribedEventHandler('modeHandler', (_, event) => {
+		const expectedEvent = {
+			'eventId': 'e9ede6a6-ade1-11e9-8a15-5998645d79ea',
+			'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+			'modeId': '57ae8db9-9187-4293-bf7c-c0218825e94e'
+		}
+		app.subscribedModeEventHandler('modeHandler', (_, event) => {
 			receivedEvent = event
-		}, 'MODE_EVENT')
+		})
 		app.handleMockCallback({
 			'lifecycle': 'EVENT',
 			'executionId': '66D91548-8643-444F-B402-F5CE832A5120',
@@ -37,25 +42,29 @@ describe('event-type-handler-spec', () => {
 					{
 						'eventTime': '2019-07-24T07:09:01Z',
 						'eventType': 'MODE_EVENT',
-						'modeEvent': {
-							'eventId': 'e9ede6a6-ade1-11e9-8a15-5998645d79ea',
-							'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
-							'modeId': '57ae8db9-9187-4293-bf7c-c0218825e94e'
-						}
+						'modeEvent': expectedEvent
 					}
 				]
 			},
 			'settings': {}
 		})
-		assert.equal(receivedEvent.eventId, 'e9ede6a6-ade1-11e9-8a15-5998645d79ea')
-		assert.equal(receivedEvent.locationId, '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5')
-		assert.equal(receivedEvent.modeId, '57ae8db9-9187-4293-bf7c-c0218825e94e')
+
+		assert.deepStrictEqual(receivedEvent, expectedEvent)
 	})
 
 	it('should handle DEVICE_LIFECYCLE_EVENT', () => {
-		app.subscribedEventHandler('deviceLifecycle', (_, event) => {
+		const expectedEvent = {
+			'lifecycle': 'UPDATE',
+			'eventId': '091bd080-ade3-11e9-aa79-415d41e7ce77',
+			'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+			'deviceId': 'ba0767c3-f883-438d-9db1-b1a84b8d347b',
+			'deviceName': '',
+			'principal': '',
+			'update': {}
+		}
+		app.subscribedDeviceLifecycleEventHandler('deviceLifecycle', (_, event) => {
 			receivedEvent = event
-		}, 'DEVICE_LIFECYCLE_EVENT')
+		})
 		app.handleMockCallback({
 			'lifecycle': 'EVENT',
 			'executionId': '6b85d1aa-a059-fe2f-ac71-f863df37da65',
@@ -78,27 +87,27 @@ describe('event-type-handler-spec', () => {
 					{
 						'eventTime': '2019-07-24T07:17:03Z',
 						'eventType': 'DEVICE_LIFECYCLE_EVENT',
-						'deviceLifecycleEvent': {
-							'lifecycle': 'UPDATE',
-							'eventId': '091bd080-ade3-11e9-aa79-415d41e7ce77',
-							'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
-							'deviceId': 'ba0767c3-f883-438d-9db1-b1a84b8d347b',
-							'deviceName': '',
-							'principal': '',
-							'update': {}
-						}
+						'deviceLifecycleEvent': expectedEvent
 					}
 				]
 			},
 			'settings': {}
 		})
-		assert.equal(receivedEvent.eventId, '091bd080-ade3-11e9-aa79-415d41e7ce77')
+		assert.deepStrictEqual(receivedEvent, expectedEvent)
 	})
 
 	it('should handle DEVICE_HEALTH_EVENT', () => {
-		app.subscribedEventHandler('deviceHealthHandler', (_, event) => {
+		const expectedEvent = {
+			'eventId': '0bde7df0-ade4-11e9-b187-3f8238130d63',
+			'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
+			'deviceId': '1ed46054-c643-4153-b50d-7509de9b237b',
+			'hubId': '',
+			'status': 'OFFLINE',
+			'reason': 'SERVICE_UNAVAILABLE'
+		}
+		app.subscribedDeviceHealthEventHandler('deviceHealth', (_, event) => {
 			receivedEvent = event
-		}, 'DEVICE_HEALTH_EVENT')
+		})
 		app.handleMockCallback({
 			'lifecycle': 'EVENT',
 			'executionId': '66b5208f-f3e2-403a-b2da-e2e34e009828',
@@ -121,26 +130,25 @@ describe('event-type-handler-spec', () => {
 					{
 						'eventTime': '2019-07-24T07:24:17Z',
 						'eventType': 'DEVICE_HEALTH_EVENT',
-						'deviceHealthEvent': {
-							'eventId': '0bde7df0-ade4-11e9-b187-3f8238130d63',
-							'locationId': '5f278baa-aff0-4cf0-a323-3d9ee1fc58d5',
-							'deviceId': '1ed46054-c643-4153-b50d-7509de9b237b',
-							'hubId': '',
-							'status': 'OFFLINE',
-							'reason': 'SERVICE_UNAVAILABLE'
-						}
+						'deviceHealthEvent': expectedEvent
 					}
 				]
 			},
 			'settings': {}
 		})
-		assert.equal(receivedEvent.eventId, '0bde7df0-ade4-11e9-b187-3f8238130d63')
+		assert.deepStrictEqual(receivedEvent, expectedEvent)
 	})
 
 	it('should handle HUB_HEALTH_EVENT', () => {
-		app.subscribedEventHandler('hubHealthHandler', (_, event) => {
+		const expectedEvent = {
+			'eventId': '12347df0-ade4-11e9-b187-3f8238130d63',
+			'locationId': '66b5208f-f3e2-4a1a-c3eb-e2e34e009828',
+			'hubId': '1935208f-f4d2-4a1a-c3eb-e2e45e008928',
+			'status': 'OFFLINE'
+		}
+		app.subscribedHubHealthEventHandler('hubHealth', (_, event) => {
 			receivedEvent = event
-		}, 'HUB_HEALTH_EVENT')
+		})
 		app.handleMockCallback({
 			'lifecycle': 'EVENT',
 			'executionId': '66b5208f-f3e2-403a-b2da-e2e34e009828',
@@ -162,21 +170,33 @@ describe('event-type-handler-spec', () => {
 					{
 						'eventTime': '2019-07-24T07:24:17Z',
 						'eventType': 'HUB_HEALTH_EVENT',
-						'hubHealthEvent': {
-							'eventId': '12347df0-ade4-11e9-b187-3f8238130d63'
-						}
+						'hubHealthEvent': expectedEvent
 					}
 				]
 			},
 			'settings': {}
 		})
-		assert.equal(receivedEvent.eventId, '12347df0-ade4-11e9-b187-3f8238130d63')
+		assert.deepStrictEqual(receivedEvent, expectedEvent)
 	})
 
 	it('should handle SECURITY_ARM_STATE_EVENT', () => {
-		app.subscribedEventHandler('hubHealthHandler', (_, event) => {
+		const expectedEvent = {
+			'eventId': '12347df0-ade4-11e9-b187-3f8238130d63',
+			'armState': 'UNKNOWN',
+			'locationId': '66b5208f-f3e2-4a1a-c3eb-e2e34e009828',
+			'optionalArguments': {
+				'property1': {
+					'valueType': 'NULL_VALUE',
+					'intValue': 0,
+					'doubleValue': 0,
+					'stringValue': 'string',
+					'boolValue': true
+				}
+			}
+		}
+		app.subscribedSecurityArmStateEventHandler('securityArmState', (_, event) => {
 			receivedEvent = event
-		}, 'SECURITY_ARM_STATE_EVENT')
+		})
 		app.handleMockCallback({
 			'lifecycle': 'EVENT',
 			'executionId': '66b5208f-f3e2-403a-b2da-e2e34e009828',
@@ -198,14 +218,12 @@ describe('event-type-handler-spec', () => {
 					{
 						'eventTime': '2019-07-24T07:24:17Z',
 						'eventType': 'SECURITY_ARM_STATE_EVENT',
-						'securityArmStateEvent': {
-							'eventId': '12347df0-ade4-11e9-b187-3f8238130d63'
-						}
+						'securityArmStateEvent': expectedEvent
 					}
 				]
 			},
 			'settings': {}
 		})
-		assert.equal(receivedEvent.eventId, '12347df0-ade4-11e9-b187-3f8238130d63')
+		assert.deepStrictEqual(receivedEvent, expectedEvent)
 	})
 })

--- a/test/unit/event-type-handler-spec.js
+++ b/test/unit/event-type-handler-spec.js
@@ -3,6 +3,7 @@ const assert = require('assert').strict
 const SmartApp = require('../../lib/smart-app')
 
 describe('event-type-handler-spec', () => {
+	/** @type {SmartApp} */
 	let app
 	let receivedEvent
 


### PR DESCRIPTION
Added consistent handling of event type subscriptions. Note that the non-device subscription lifecycle events do not return the subscription name specified in the API call. As a result, there is no basis for dispatching them to the proper named handler. A request has been made to correct that problem in the SmartThings platform, but in the meantime the SDK is modified to accept an optional third argument to `subscribedEventHandler` to specify the type of event being handled. This argument should _not_ be specified for device events, but is required for other event types.

Because the handler name is not returned in the lifecycle event only one handler is possible for each non-device event type. 

Once the platform change has been made this SDK will be updated to use the returned handler name, and the one handler limitation will no longer apply. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
