### PR TITLE
test: improve code coverage

### DIFF
--- a/lib/pages/device-setting.js
+++ b/lib/pages/device-setting.js
@@ -13,7 +13,7 @@ module.exports = class DeviceSetting extends SectionSetting {
 	/**
 	 * Indicates if this device setting can have multiple values.
 	 *
-	 * @param {Boolean} multiple
+	 * @param {Boolean} value
 	 * @default false
 	 * @returns {DeviceSetting} Device Setting instance
 	 */
@@ -31,18 +31,6 @@ module.exports = class DeviceSetting extends SectionSetting {
 	 */
 	closeOnSelection(value) {
 		this._closeOnSelection = value
-		return this
-	}
-
-	/**
-	 * Indicates if this input should refresh configs after a change in value.
-	 *
-	 * @param {Boolean} value
-	 * @default true
-	 * @returns {DeviceSetting} Device Setting instance
-	 */
-	submitOnChange(value) {
-		this._submitOnChange = value
 		return this
 	}
 
@@ -83,7 +71,7 @@ module.exports = class DeviceSetting extends SectionSetting {
 	/**
 	 * The excluded capabilities for the device(s) options.
 	 *
-	 * @param {Array.<String>} items Each string has a max length of 128 characters
+	 * @param {String|Array.<String>} capabilities Each string has a max length of 128 characters
 	 * @returns {DeviceSetting} Device Setting instance
 	 */
 	excludeCapabilities(capabilities) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "xo",
     "test:unit": "mocha test/unit",
     "test:functional": "mocha test/functional",
-    "test": "xo && nyc mocha test/unit",
+    "test": "xo && nyc mocha test/unit/**",
     "start": "node ./smart-app.js",
     "debug": "node --inspect ./lib/smart-app.js",
     "semantic-release": "semantic-release -e ./config/release.config.js",
@@ -61,6 +61,14 @@
     "semantic-release": "^15.13.12",
     "sinon": "^7.3.2",
     "xo": "~0.24.0"
+  },
+  "nyc": {
+    "watermarks": {
+      "lines": [40, 95],
+      "functions": [40, 95],
+      "branches": [40, 95],
+      "statements": [40, 95]
+    }
   },
   "xo": {
     "space": false,

--- a/test/unit/pages/boolean-setting-spec.js
+++ b/test/unit/pages/boolean-setting-spec.js
@@ -1,8 +1,8 @@
 /* eslint no-undef: "off" */
 const {expect} = require('chai')
-const Page = require('../../lib/pages/page')
-const Section = require('../../lib/pages/section')
-const BooleanSetting = require('../../lib/pages/boolean-setting')
+const Page = require('../../../lib/pages/page')
+const Section = require('../../../lib/pages/section')
+const BooleanSetting = require('../../../lib/pages/boolean-setting')
 
 describe('boolean-setting', () => {
 	let page = {}

--- a/test/unit/pages/device-setting-spec.js
+++ b/test/unit/pages/device-setting-spec.js
@@ -1,0 +1,134 @@
+/* eslint no-undef: "off" */
+const {expect} = require('chai')
+const Page = require('../../../lib/pages/page')
+const Section = require('../../../lib/pages/section')
+const DeviceSetting = require('../../../lib/pages/device-setting')
+
+describe('device-setting', () => {
+	let page = {}
+	let section = {}
+	const expected = {
+		// Super
+		id: 'testSetting',
+		name: 'myTestDeviceSettingName',
+		description: 'myTestDviceSettingDesc',
+		disabled: true,
+		required: true,
+		defaultValue: 'defaultValue',
+		//  End Super
+		submitOnChange: true,
+		multiple: true,
+		closeOnSelection: true,
+		preselect: true,
+		capabilities: ['switch'],
+		excludeCapabilities: ['light'],
+		permissions: 'rwx'
+	}
+
+	beforeEach(() => {
+		page = new Page('testPage')
+		section = new Section(page, 'testSection')
+	})
+
+	it('should set `multiple`', () => {
+		const setting = new DeviceSetting(section, 'testDevice')
+		expect(setting.toJson()).to.have.ownProperty('multiple')
+		expect(setting.toJson().multiple).to.equal(false)
+	})
+
+	it('should set `closeOnSelection`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.closeOnSelection(expected.closeOnSelection)
+		expect(setting.toJson()).to.have.ownProperty('closeOnSelection')
+		expect(setting.toJson().closeOnSelection).to.equal(expected.closeOnSelection)
+	})
+
+	it('should set `preselect`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.preselect(expected.preselect)
+		expect(setting.toJson()).to.have.ownProperty('preselect')
+		expect(setting.toJson().preselect).to.equal(expected.preselect)
+	})
+
+	it('should set `capabilities`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.capabilities(expected.capabilities)
+		expect(setting.toJson()).to.have.ownProperty('capabilities')
+		expect(setting.toJson().capabilities).to.have.members(expected.capabilities)
+	})
+
+	it('should set `capability`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.capability(expected.capabilities[0])
+		expect(setting.toJson()).to.have.ownProperty('capabilities')
+		expect(setting.toJson().capabilities).to.have.members(expected.capabilities)
+	})
+
+	it('should set `excludeCapabilities`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.excludeCapabilities(expected.excludeCapabilities)
+		expect(setting.toJson()).to.have.ownProperty('excludeCapabilities')
+		expect(setting.toJson().excludeCapabilities).to.have.members(expected.excludeCapabilities)
+	})
+
+	it('should set `excludeCapability`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.excludeCapability(expected.excludeCapabilities[0])
+		expect(setting.toJson()).to.have.ownProperty('excludeCapabilities')
+		expect(setting.toJson().excludeCapabilities).to.have.members(expected.excludeCapabilities)
+	})
+
+	it('should set `super.submitOnChange`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.submitOnChange(expected.submitOnChange)
+		expect(setting.toJson()).to.have.ownProperty('submitOnChange')
+		expect(setting.toJson().submitOnChange).to.equal(expected.submitOnChange)
+	})
+
+	it('should set `permissions` correctly with `rwx`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.permissions(expected.permissions)
+		expect(setting.toJson()).to.have.ownProperty('permissions')
+		expect(setting.toJson().permissions).to.have.members(['r', 'w', 'x'])
+	})
+
+	it('should set `permissions` correctly with `r`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.permissions(expected.permissions[0])
+		expect(setting.toJson()).to.have.ownProperty('permissions')
+		expect(setting.toJson().permissions).to.have.members(['r'])
+	})
+
+	it('should set `permissions` correctly with `[r,w,x]`', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		setting.permissions(expected.permissions.split(''))
+		expect(setting.toJson()).to.have.ownProperty('permissions')
+		expect(setting.toJson().permissions).to.have.members(['r', 'w', 'x'])
+	})
+
+	it('should default `permissions` to [r]', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		expect(setting.toJson()).to.have.ownProperty('permissions')
+		expect(setting.toJson().permissions).to.have.members(['r'])
+	})
+
+	it('`toJson()` to return super properties at least', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		expect(setting.toJson()).to.have.ownProperty('id')
+		expect(setting.toJson()).to.have.ownProperty('name')
+		expect(setting.toJson()).to.have.ownProperty('description')
+		expect(setting.toJson()).to.have.ownProperty('required')
+	})
+
+	it('`toJson()` to return super properties at least', () => {
+		const setting = new DeviceSetting(section, expected.id)
+		expect(setting.toJson()).to.have.ownProperty('type')
+		expect(setting.toJson().type).to.equal('DEVICE')
+
+		expect(setting.toJson()).to.have.ownProperty('description')
+		expect(setting.toJson().description).to.equal('Tap to set')
+
+		expect(setting.toJson()).to.have.ownProperty('multiple')
+		expect(setting.toJson().multiple).to.equal(false)
+	})
+})

--- a/test/unit/pages/section-setting-spec.js
+++ b/test/unit/pages/section-setting-spec.js
@@ -1,0 +1,94 @@
+/* eslint no-undef: "off" */
+const {expect} = require('chai')
+const Page = require('../../../lib/pages/page')
+const Section = require('../../../lib/pages/section')
+const SectionSetting = require('../../../lib/pages/section-setting')
+
+describe('section-setting', () => {
+	let page = {}
+	let section = {}
+	let expected = {}
+
+	beforeEach(() => {
+		page = new Page('testPage')
+		section = new Section(page, 'testSection')
+
+		expected = {
+			id: 'testSetting',
+			name: 'myTestSectionSettingName',
+			description: 'myTestSectionSettingDesc',
+			defaultValue: 'defaultValue',
+			disabled: true,
+			required: true,
+			submitOnChange: true
+		}
+	})
+
+	it('should include `required` property', () => {
+		let setting = new SectionSetting(section, 'testSection1')
+		expect(setting.toJson()).to.have.ownProperty('required')
+
+		setting = new SectionSetting(section, 'testSection2')
+		setting.required(false)
+		expect(setting.toJson()).to.have.ownProperty('required')
+	})
+
+	it('should default `required` to false', () => {
+		const setting = new SectionSetting(section, 'testSection')
+		expect(setting.toJson().required).to.equal(false)
+	})
+
+	it('should set `defaultValue`', () => {
+		const setting = new SectionSetting(section, expected.id)
+		setting.defaultValue(expected.defaultValue)
+		expect(setting.toJson().defaultValue).to.equal(expected.defaultValue)
+	})
+
+	it('should set `submitOnChange`', () => {
+		const setting = new SectionSetting(section, expected.id)
+		setting.submitOnChange(expected.submitOnChange)
+		expect(setting.toJson().submitOnChange).to.equal(expected.submitOnChange)
+	})
+
+	it('should omit `submitOnChange` by default', () => {
+		const setting = new SectionSetting(section, expected.id)
+		expect(setting.toJson()).to.not.have.ownProperty('submitOnChange')
+	})
+
+	it('should set `disabled`', () => {
+		const setting = new SectionSetting(section, expected.id)
+		setting.disabled(expected.disabled)
+		expect(setting.toJson().disabled).to.equal(expected.disabled)
+	})
+
+	it('should omit `disabled` by default', () => {
+		const setting = new SectionSetting(section, expected.id)
+		expect(setting.toJson()).to.not.have.ownProperty('disabled')
+	})
+
+	it('should set name to a string value', () => {
+		const setting = new SectionSetting(section, 'testSection')
+		setting.name(() => expected.name)
+		expect(setting.toJson()).to.have.ownProperty('name')
+		expect(setting.toJson()).to.have.property('name', expected.name)
+	})
+
+	it('should default name to an i18n key', () => {
+		const setting = new SectionSetting(section, 'testSection')
+		expect(setting.toJson()).to.have.ownProperty('name')
+		expect(setting.toJson()).to.have.property('name', 'pages.testPage.settings.testSection.name')
+	})
+
+	it('should set description to a string value', () => {
+		const setting = new SectionSetting(section, 'testSection')
+		setting.description(() => expected.description)
+		expect(setting.toJson()).to.have.ownProperty('description')
+		expect(setting.toJson()).to.have.property('description', expected.description)
+	})
+
+	it('should default description to an i18n key', () => {
+		const setting = new SectionSetting(section, 'testSection')
+		expect(setting.toJson()).to.have.ownProperty('description')
+		expect(setting.toJson()).to.have.property('description', 'pages.testPage.settings.testSection.description')
+	})
+})

--- a/test/unit/util/authorizer-spec.js
+++ b/test/unit/util/authorizer-spec.js
@@ -7,10 +7,10 @@ const {expect, assert} = require('chai')
 const proxyquire = require('proxyquire')
 const sshpk = require('sshpk')
 const httpSignature = require('http-signature')
-const SmartApp = require('../../lib/smart-app')
-const Log = require('../../lib/util/log')
+const SmartApp = require('../../../lib/smart-app')
+const Log = require('../../../lib/util/log')
 
-const Authorizer = proxyquire('../../lib/util/authorizer', {
+const Authorizer = proxyquire('../../../lib/util/authorizer', {
 	'http-signature': {
 		parseRequest: req => {
 			return {keyId: req.keyId}
@@ -21,8 +21,8 @@ const Authorizer = proxyquire('../../lib/util/authorizer', {
 	}
 })
 
-const publicKeyFilePath = path.resolve(__dirname, '../fixtures/unit_test_rsa.key')
-const publicCertFilePath = path.resolve(__dirname, '../fixtures/unit_test_cert.crt')
+const publicKeyFilePath = path.resolve(__dirname, '../../fixtures/unit_test_rsa.key')
+const publicCertFilePath = path.resolve(__dirname, '../../fixtures/unit_test_cert.crt')
 describe('authorizer-spec', () => {
 	let publicKey
 	let publicCert

--- a/test/unit/util/configuration-error-spec.js
+++ b/test/unit/util/configuration-error-spec.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-undef, no-unused-expressions */
+const {expect} = require('chai')
+const ConfigurationError = require('../../../lib/util/configuration-error')
+
+describe('configuration-error-spec', () => {
+	it('should return an undefined message if not set', () => {
+		const error = new ConfigurationError()
+		expect(error.message).to.be.undefined
+	})
+
+	it('should return an undefined message if not set', () => {
+		const error = new ConfigurationError('My Error')
+		expect(error.message).to.be.equal('My Error')
+	})
+
+	it('should return the message by `toString()` usage', () => {
+		const error = new ConfigurationError('My Error')
+		expect(error.toString()).to.be.equal('My Error')
+	})
+
+	it('should include the message key', () => {
+		const error = new ConfigurationError()
+		expect(error).to.include.keys('message')
+	})
+})

--- a/test/unit/util/endpoint-context-spec.js
+++ b/test/unit/util/endpoint-context-spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, no-unused-expressions */
 const chai = require('chai')
-const EndpointContext = require('../../lib/util/endpoint-context')
-const SmartApp = require('../../lib/smart-app')
+const EndpointContext = require('../../../lib/util/endpoint-context')
+const SmartApp = require('../../../lib/smart-app')
 
 const {expect} = chai
 chai.use(require('chai-datetime'))

--- a/test/unit/util/log-spec.js
+++ b/test/unit/util/log-spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, no-unused-expressions */
 const sinon = require('sinon')
 const {expect} = require('chai')
-const Log = require('../../lib/util/log')
+const Log = require('../../../lib/util/log')
 
 const event = {
 	lifecycle: 'CONFIGURATION',


### PR DESCRIPTION
Ongoing effort toward #100 

<!-- Describe your pull request. -->

`test:` Add nyc low watermark of 40%, high of 95%
`fix:` sub-folder unit tests not running
`fix:` Remove submitOnChange from device-setting (Exists in super)
`fix:` jsdocs in device-setting
`test:` Add configuration-error spec (100% cov)
`test:` Add device-setting-spec (97.5% cov)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
