### PR TITLE
fix: pagecallback does not return smartapp instance

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -326,7 +326,6 @@ module.exports = class SmartApp {
 	 * @param page { import("./pages/page") } Chainable page instance
 	 * @param {ConfigurationData} data Optionally access the raw configuration
 	 * data event object
-	 * @returns {SmartApp} SmartApp instance
 	 */
 
 	/**


### PR DESCRIPTION
This fixes the warnings that are shown when using the `PageCallback` – it erroneously thinks we return an instance of `SmartApp`, but we do not. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
