### PR TITLE
feat: EnumSettings i18n

### DIFF
--- a/lib/pages/enum-setting.js
+++ b/lib/pages/enum-setting.js
@@ -11,14 +11,14 @@ module.exports = class EnumSetting extends SectionSetting {
 
 	/**
 	 * @typedef GroupedOption
-	 * @prop {String} name The display name of this group of enum options. Max length 128 characters.
-	 * @prop {Array.<Option>} options The enum options.
+	 * @property {String} name The display name of this group of enum options. Max length 128 characters.
+	 * @property {Array<Option>} options The enum options.
 	 */
 
 	/**
 	 * @typedef Option
-	 * @prop {String} id The unique ID for this option. Max length 128 characters.
-	 * @prop {String} name The display name for this option. Max length 128 characters.
+	 * @property {String} id The unique ID for this option. Max length 128 characters.
+	 * @property {String} name The display name for this option. Max length 128 characters.
 	 */
 
 	/**

--- a/lib/pages/enum-setting.js
+++ b/lib/pages/enum-setting.js
@@ -60,7 +60,10 @@ module.exports = class EnumSetting extends SectionSetting {
 	/**
 	 * Display the enum options as named groups.
 	 *
-	 * @param {Array<GroupedOption>} groups Array of grouped options
+	 * @param {Object.<string, Array<String>>|
+	 *  Object.<String, Object.<String, String>>|
+	 * 	Array<Object.<String, Object.<String, String>>>|
+	 * 	Array<GroupedOption>} groups Array of grouped options
 	 * @returns {EnumSetting} Enum Setting instance
 	 * @example
 	 * const groups = [{
@@ -78,34 +81,81 @@ module.exports = class EnumSetting extends SectionSetting {
 	 *         }]
 	 *     }
 	 * ]
-	 * section.enumSetting('id').groupedOptions(groups)
+	 * @example
+	 * section.enumSetting('id')
+	 * 	   .groupedOptions({Colors: { 'red', 'blue', 'green'}})
+	 * @example
+	 * section.enumSetting('id')
+	 * 	   .groupedOptions({Flavors: ['tart', 'salty', 'sweet']})
 	 */
 	groupedOptions(groups) {
-		this._groupedOptions = groups
+		const values = []
+
 		if (Array.isArray(groups)) {
 			for (const group of groups) {
 				if (group instanceof Object) {
 					const groupName = group.name
-					group.name = this.i18nOptionGroupKey(group.name)
+					group.name = this._section._page.headers ? this.i18nOptionGroupKey(group.name) : group.name
+
 					for (const option of group.options) {
-						option.name = this.i18nOptionGroupOptionKey(groupName, option.name)
+						option.name = this._section._page.headers ? this.i18nOptionGroupOptionKey(groupName, option.name) : option.name
 					}
+
+					values.push(group)
 				} else {
 					throw new TypeError(`${typeof group} not valid for options group item`)
+				}
+			}
+		} else if (groups instanceof Object) {
+			for (const property in groups) {
+				if (Object.prototype.hasOwnProperty.call(groups, property)) {
+					const index = Object.keys(groups).indexOf(property)
+					const group = {name: property, options: []}
+
+					// Convert to i18nKey if necessary
+					group.name = this._section._page.headers ? this.i18nOptionGroupKey(group.name) : group.name
+
+					// Push group to output
+					values.push(group)
+
+					const propertyGroup = groups[property]
+					if (Array.isArray(groups[property])) {
+						values[index].options = propertyGroup.map(name => {
+							return {
+								id: name,
+								name: this._section._page.headers ?
+									this.i18nOptionGroupOptionKey(group.name, name) :
+									name}
+						})
+					} else if (groups[property] instanceof Object) {
+						for (const groupProperty in groups[property]) {
+							if (Object.prototype.hasOwnProperty.call(groups[property], groupProperty)) {
+								const option = {id: groupProperty, name: groups[property][groupProperty]}
+
+								// Convert to i18nKey if necessary
+								option.name = this._section._page.headers ?
+									this.i18nOptionGroupOptionKey(group.name, groups[property][groupProperty]) :
+									groups[property][groupProperty]
+
+								// Push to output
+								values[index].options.push(option)
+							}
+						}
+					}
 				}
 			}
 		} else {
 			throw new TypeError(`${typeof groups} not valid for options group`)
 		}
 
-		this._groupedOptions = groups
+		this._groupedOptions = values
 		return this
 	}
 
 	/**
 	 * The enum options.
 	 *
-	 * @param {Option | Array.<Option>} options Single or array of options
+	 * @param {Array<String> | Object | Option | Array.<Option>} options Single or array of options
 	 * @returns {EnumSetting} Enum Setting instance
 	 * @example
 	 * const options = [{
@@ -122,15 +172,24 @@ module.exports = class EnumSetting extends SectionSetting {
 	options(options) {
 		const values = []
 		if (Array.isArray(options)) {
-			for (const it of options) {
-				it.name = this.i18nOptionKey(it.name)
+			for (let it of options) {
+				if (typeof it === 'string' || it instanceof String) {
+					it = {id: it, name: it}
+				}
+
+				// Convert to i18nKey if necessary
+				it.name = this._section._page.headers ? this.i18nOptionKey(it.name) : it.name
+
 				values.push(it)
 			}
 		} else if (options instanceof Object) {
 			for (const property in options) {
 				if (Object.prototype.hasOwnProperty.call(options, property)) {
-					this.i18nOptionKey(options[property])
-					values.push({id: property, name: options[property]})
+					const option = {id: property, name: options[property]}
+
+					// Convert to i18nKey if necessary
+					option.name = this._section._page.headers ? this.i18nOptionKey(options[property]) : options[property]
+					values.push(option)
 				}
 			}
 		} else {
@@ -149,14 +208,14 @@ module.exports = class EnumSetting extends SectionSetting {
 	 * @returns {EnumSetting} Enum Setting instance
 	 */
 	submitOnChange(value) {
-		this._submitOnChange = value
+		super._submitOnChange = value
 		return this
 	}
 
 	/**
 	 * Style of the setting.
 	 *
-	 * @param {('COMPLETE'|'ERROR'|'DEFAULT'|'DROPDOWN')} value
+	 * @param {('COMPLETE'|'ERROR'|'DEFAULT'|'DROPDOWN')} value Setting input style
 	 * @returns {EnumSetting} Enum Setting instance
 	 */
 	style(value) {
@@ -184,8 +243,6 @@ module.exports = class EnumSetting extends SectionSetting {
 					result.groupedOptions[i].options[g].name = this.translate(option.name)
 				}
 			}
-		} else {
-			result.groupedOptions = this._groupedOptions
 		}
 
 		if (Array.isArray(this._options)) {
@@ -194,8 +251,6 @@ module.exports = class EnumSetting extends SectionSetting {
 				const it = this._options[i]
 				result.options[i].name = this.translate(it.name)
 			}
-		} else {
-			result.options = this._options
 		}
 
 		if (this._style) {

--- a/lib/pages/enum-setting.js
+++ b/lib/pages/enum-setting.js
@@ -45,33 +45,59 @@ module.exports = class EnumSetting extends SectionSetting {
 		return this
 	}
 
+	i18nOptionKey(property) {
+		return this._section._page.i18nKey(`settings.${this._id}.options.${property}.name`)
+	}
+
+	i18nOptionGroupKey(property) {
+		return this._section._page.i18nKey(`settings.${this._id}.groups.${property}.name`)
+	}
+
+	i18nOptionGroupOptionKey(groupName, property) {
+		return this._section._page.i18nKey(`settings.${this._id}.groups.${groupName}.options.${property}.name`)
+	}
+
 	/**
 	 * Display the enum options as named groups.
 	 *
-	 * @param {Array.<GroupedOption>} groups Array of grouped options
+	 * @param {Array<GroupedOption>} groups Array of grouped options
 	 * @returns {EnumSetting} Enum Setting instance
-	 *
 	 * @example
-	 ```javascript
-const groups = [{
-        name: 'First Group',
-        options: [{
-            id: 'option-001',
-            name: 'Option 1'
-        }]
-    },
-    {
-        name: 'Second Group',
-        options: [{
-            id: 'option-002',
-            name: 'Option 2'
-        }]
-    }
-]
-section.enumSetting('id').groupedOptions(groups)
-	 ```
+	 * const groups = [{
+	 *         name: 'First Group',
+	 *         options: [{
+	 *             id: 'option-001',
+	 *             name: 'Option 1'
+	 *         }]
+	 *     },
+	 *     {
+	 *         name: 'Second Group',
+	 *         options: [{
+	 *             id: 'option-002',
+	 *             name: 'Option 2'
+	 *         }]
+	 *     }
+	 * ]
+	 * section.enumSetting('id').groupedOptions(groups)
 	 */
 	groupedOptions(groups) {
+		this._groupedOptions = groups
+		if (Array.isArray(groups)) {
+			for (const group of groups) {
+				if (group instanceof Object) {
+					const groupName = group.name
+					group.name = this.i18nOptionGroupKey(group.name)
+					for (const option of group.options) {
+						option.name = this.i18nOptionGroupOptionKey(groupName, option.name)
+					}
+				} else {
+					throw new TypeError(`${typeof group} not valid for options group item`)
+				}
+			}
+		} else {
+			throw new TypeError(`${typeof groups} not valid for options group`)
+		}
+
 		this._groupedOptions = groups
 		return this
 	}
@@ -82,33 +108,28 @@ section.enumSetting('id').groupedOptions(groups)
 	 * @param {Option | Array.<Option>} options Single or array of options
 	 * @returns {EnumSetting} Enum Setting instance
 	 * @example
-	 ```javascript
-const options = [{
-        id: 'option-001',
-        name: 'Option 1'
-    },
-    {
-        id: 'option-002',
-        name: 'Option 2'
-    }
-]
-section.enumSetting('id').options(options)
-	 ```
+	 * const options = [{
+	 *         id: 'option-001',
+	 *         name: 'Option 1'
+	 *     },
+	 *     {
+	 *         id: 'option-002',
+	 *         name: 'Option 2'
+	 *     }
+	 * ]
+	 * section.enumSetting('id').options(options)
 	 */
 	options(options) {
 		const values = []
 		if (Array.isArray(options)) {
 			for (const it of options) {
-				if (it instanceof Object) {
-					values.push(it)
-				} else {
-					const item = String(it)
-					values.push({id: item, name: item})
-				}
+				it.name = this.i18nOptionKey(it.name)
+				values.push(it)
 			}
 		} else if (options instanceof Object) {
 			for (const property in options) {
 				if (Object.prototype.hasOwnProperty.call(options, property)) {
+					this.i18nOptionKey(options[property])
 					values.push({id: property, name: options[property]})
 				}
 			}
@@ -135,7 +156,7 @@ section.enumSetting('id').options(options)
 	/**
 	 * Style of the setting.
 	 *
-	 * @param {('COMPLETE','ERROR','DEFAULT','DROPDOWN')} value
+	 * @param {('COMPLETE'|'ERROR'|'DEFAULT'|'DROPDOWN')} value
 	 * @returns {EnumSetting} Enum Setting instance
 	 */
 	style(value) {
@@ -153,16 +174,28 @@ section.enumSetting('id').options(options)
 			result.closeOnSelection = this._closeOnSelection
 		}
 
-		if (this._groupedOptions) {
+		if (Array.isArray(this._groupedOptions)) {
+			result.groupedOptions = this._groupedOptions
+			for (let i = 0; i < this._groupedOptions.length; i++) {
+				const group = this._groupedOptions[i]
+				result.groupedOptions[i].name = this.translate(group.name)
+				for (let g = 0; g < this._groupedOptions[i].options.length; g++) {
+					const option = this._groupedOptions[i].options[g]
+					result.groupedOptions[i].options[g].name = this.translate(option.name)
+				}
+			}
+		} else {
 			result.groupedOptions = this._groupedOptions
 		}
 
-		if (this._options) {
+		if (Array.isArray(this._options)) {
 			result.options = this._options
-		}
-
-		if (this._submitOnChange) {
-			result.submitOnChange = this._submitOnChange
+			for (let i = 0; i < this._options.length; i++) {
+				const it = this._options[i]
+				result.options[i].name = this.translate(it.name)
+			}
+		} else {
+			result.options = this._options
 		}
 
 		if (this._style) {

--- a/test/unit/locales/fr.json
+++ b/test/unit/locales/fr.json
@@ -18,5 +18,12 @@
 	"whenDoorOpensAndCloses": "whenDoorOpensAndCloses",
 	"turnLightsOnAndOff": "turnLightsOnAndOff",
 	"When anything opens or closes": "When anything opens or closes",
-	"Any open or close sensor": "Any open or close sensor"
+	"Any open or close sensor": "Any open or close sensor",
+	"pages.i18nMainPage.sections.pickFromList.name": "Choisissez parmi une liste",
+	"pages.i18nMainPage.sections.pickFromGroupedList.name": "Choisissez parmi une liste groupée",
+	"pages.i18nMainPage.settings.enumList.name": "Les options",
+	"pages.i18nMainPage.settings.enumList.options.optionName001.name": "Nom de l'option 1",
+	"pages.i18nMainPage.settings.enumGroupList.name": "Liste de groupe d'énumération",
+	"pages.i18nMainPage.settings.enumGroupList.groups.groupName001.name": "Options groupées",
+	"pages.i18nMainPage.settings.enumGroupList.groups.groupName001.options.optionGroupName001.name": "Nom du groupe d'options 1"
 }

--- a/test/unit/pagebuilder-i18n-spec.js
+++ b/test/unit/pagebuilder-i18n-spec.js
@@ -24,9 +24,34 @@ describe('pagebuilder-i18n-spec', () => {
 				.permissions('rx')
 		})
 
+		page.section('pickFromList', section => {
+			section.enumSetting('enumList')
+				.options([
+					{
+						id: 'option-001',
+						name: 'optionName001'
+					}
+				])
+		})
+
+		page.section('pickFromGroupedList', section => {
+			section.enumSetting('enumGroupList')
+				.groupedOptions([
+					{
+						name: 'groupName001',
+						options: [
+							{
+								id: 'option-001',
+								name: 'optionGroupName001'
+							}
+						]
+					}
+				])
+		})
+
 		const json = page.toJson()
 		// Console.log(JSON.stringify(json, null, 2))
-		expect(json.sections.length).to.equal(2)
+		expect(json.sections.length).to.equal(4)
 
 		expect(json.sections[0].name).to.equal('Quand cette porte s\'ouvre et se ferme')
 		expect(json.sections[0].settings.length).to.equal(1)
@@ -48,6 +73,19 @@ describe('pagebuilder-i18n-spec', () => {
 		expect(json.sections[1].settings[0].permissions[0]).to.equal('r')
 		expect(json.sections[1].settings[0].permissions[1]).to.equal('x')
 		expect(json.sections[1].settings[0].capabilities[0]).to.equal('switch')
+
+		expect(json.sections[2].name).to.equal('Choisissez parmi une liste')
+		expect(json.sections[2].settings.length).to.equal(1)
+		expect(json.sections[2].settings[0].id).to.equal('enumList')
+		expect(json.sections[2].settings[0].name).to.equal('Les options')
+		expect(json.sections[2].settings[0].options[0].name).to.equal('Nom de l\'option 1')
+
+		expect(json.sections[3].name).to.equal('Choisissez parmi une liste groupée')
+		expect(json.sections[3].settings.length).to.equal(1)
+		expect(json.sections[3].settings[0].id).to.equal('enumGroupList')
+		expect(json.sections[3].settings[0].name).to.equal('Liste de groupe d\'énumération')
+		expect(json.sections[3].settings[0].groupedOptions[0].name).to.equal('Options groupées')
+		expect(json.sections[3].settings[0].groupedOptions[0].options[0].name).to.equal('Nom du groupe d\'options 1')
 	})
 
 	it('should allow overrides', () => {

--- a/test/unit/pagebuilder-spec.js
+++ b/test/unit/pagebuilder-spec.js
@@ -182,6 +182,73 @@ describe('pagebuilder', () => {
 		expect(json.sections[0].settings[2].options[2].name).to.equal('Strawberry')
 	})
 
+	it('groupedOptions formats', () => {
+		const page = new Page('mainPage')
+
+		page.section('none', section => {
+			section.enumSetting('standardOptions').groupedOptions([
+				{name: 'Group One', options: [{id: 'g1one', name: 'One'}, {id: 'g1two', name: 'Two'}]},
+				{name: 'Group Two', options: [{id: 'g2one', name: 'One'}, {id: 'g2two', name: 'Two'}]}
+			])
+			section.enumSetting('mapOptions').groupedOptions({
+				Colors: {red: 'Red', green: 'Green', blue: 'Blue'},
+				Flavors: {vanilla: 'Vanilla', chocolate: 'Chocolate', strawberry: 'Strawberry'}
+			})
+			section.enumSetting('simpleOptions').groupedOptions({
+				Colors: ['Red', 'Green', 'Blue'],
+				Flavors: ['Vanilla', 'Chocolate', 'Strawberry']
+			})
+		})
+
+		const json = page.toJson()
+		// Standard Options - group 1
+		expect(json.sections[0].settings[0].groupedOptions[0].name).to.equal('Group One')
+		expect(json.sections[0].settings[0].groupedOptions[0].options[0].id).to.equal('g1one')
+		expect(json.sections[0].settings[0].groupedOptions[0].options[0].name).to.equal('One')
+		expect(json.sections[0].settings[0].groupedOptions[0].options[1].id).to.equal('g1two')
+		expect(json.sections[0].settings[0].groupedOptions[0].options[1].name).to.equal('Two')
+		// Standard Options - group 2
+		expect(json.sections[0].settings[0].groupedOptions[1].name).to.equal('Group Two')
+		expect(json.sections[0].settings[0].groupedOptions[1].options[0].id).to.equal('g2one')
+		expect(json.sections[0].settings[0].groupedOptions[1].options[0].name).to.equal('One')
+		expect(json.sections[0].settings[0].groupedOptions[1].options[1].id).to.equal('g2two')
+		expect(json.sections[0].settings[0].groupedOptions[1].options[1].name).to.equal('Two')
+
+		// Map Options - group 1
+		expect(json.sections[0].settings[1].groupedOptions[0].name).to.equal('Colors')
+		expect(json.sections[0].settings[1].groupedOptions[0].options[0].id).to.equal('red')
+		expect(json.sections[0].settings[1].groupedOptions[0].options[0].name).to.equal('Red')
+		expect(json.sections[0].settings[1].groupedOptions[0].options[1].id).to.equal('green')
+		expect(json.sections[0].settings[1].groupedOptions[0].options[1].name).to.equal('Green')
+		expect(json.sections[0].settings[1].groupedOptions[0].options[2].id).to.equal('blue')
+		expect(json.sections[0].settings[1].groupedOptions[0].options[2].name).to.equal('Blue')
+		// Map Options - group 2
+		expect(json.sections[0].settings[1].groupedOptions[1].name).to.equal('Flavors')
+		expect(json.sections[0].settings[1].groupedOptions[1].options[0].id).to.equal('vanilla')
+		expect(json.sections[0].settings[1].groupedOptions[1].options[0].name).to.equal('Vanilla')
+		expect(json.sections[0].settings[1].groupedOptions[1].options[1].id).to.equal('chocolate')
+		expect(json.sections[0].settings[1].groupedOptions[1].options[1].name).to.equal('Chocolate')
+		expect(json.sections[0].settings[1].groupedOptions[1].options[2].id).to.equal('strawberry')
+		expect(json.sections[0].settings[1].groupedOptions[1].options[2].name).to.equal('Strawberry')
+
+		// Simple Options - group 1
+		expect(json.sections[0].settings[2].groupedOptions[0].name).to.equal('Colors')
+		expect(json.sections[0].settings[2].groupedOptions[0].options[0].id).to.equal('Red')
+		expect(json.sections[0].settings[2].groupedOptions[0].options[0].name).to.equal('Red')
+		expect(json.sections[0].settings[2].groupedOptions[0].options[1].id).to.equal('Green')
+		expect(json.sections[0].settings[2].groupedOptions[0].options[1].name).to.equal('Green')
+		expect(json.sections[0].settings[2].groupedOptions[0].options[2].id).to.equal('Blue')
+		expect(json.sections[0].settings[2].groupedOptions[0].options[2].name).to.equal('Blue')
+		// Simple Options - group 2
+		expect(json.sections[0].settings[2].groupedOptions[1].name).to.equal('Flavors')
+		expect(json.sections[0].settings[2].groupedOptions[1].options[0].id).to.equal('Vanilla')
+		expect(json.sections[0].settings[2].groupedOptions[1].options[0].name).to.equal('Vanilla')
+		expect(json.sections[0].settings[2].groupedOptions[1].options[1].id).to.equal('Chocolate')
+		expect(json.sections[0].settings[2].groupedOptions[1].options[1].name).to.equal('Chocolate')
+		expect(json.sections[0].settings[2].groupedOptions[1].options[2].id).to.equal('Strawberry')
+		expect(json.sections[0].settings[2].groupedOptions[1].options[2].name).to.equal('Strawberry')
+	})
+
 	it('page setting', () => {
 		const page = new Page('mainPage')
 


### PR DESCRIPTION
<!-- Describe your pull request. -->
EnumSettings did not support i18n for the following: 
* `options.name`
* `groupedOptions[0].name`
* `groupedOptions[0].options[0].name`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
