### PR TITLE
fix: catch 404 exception from device health for unenrolled devices

### DIFF
--- a/lib/platform/devices.js
+++ b/lib/platform/devices.js
@@ -99,9 +99,12 @@ module.exports = class Devices extends Base {
 	}
 
 	getHealth(deviceId) {
-		return this.st.client.request(`devices/${deviceId}/health`).catch(() => {
-			// eslint-disable-next-line prefer-promise-reject-errors
-			return Promise.reject({state: 'UNKNOWN'})
+		return this.st.client.request(`devices/${deviceId}/health`).catch(error => {
+			if (error.statusCode === 404) {
+				return {state: 'UNKNOWN'}
+			}
+
+			return Promise.reject(error)
 		})
 	}
 


### PR DESCRIPTION
Works around a problem in the API where a 404 error is returned from device health status queries for devices that do exist but aren't enrolled in device health. Arguably the API itself should be changed to not do that, but in the meantime, this work-around catches the error and returns an 'UNKNOWN' status for the health of the device.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
