### PR TITLE
fix: release semaphore when sequential api throws non-401 errors

### DIFF
--- a/lib/platform/client.js
+++ b/lib/platform/client.js
@@ -48,7 +48,7 @@ class Client {
 		}
 
 		return rp(opts).catch(error => {
-			logError(this._log, error)
+			throw new ClientError(error)
 		})
 	}
 
@@ -97,14 +97,14 @@ class Client {
 					opts.headers.Authorization = 'Bearer ' + client.authToken
 
 					return rp(opts).catch(error => {
-						logError(client._log, error)
+						release()
+						throw new ClientError(error)
 					})
 				}
-			} else {
-				logError(client._log, error)
 			}
 
 			release()
+			throw new ClientError(error)
 		}).then(async data => {
 			release()
 			return data
@@ -114,10 +114,6 @@ class Client {
 
 exports.client = function (authToken, clientId, clientSecret) {
 	return new Client(authToken, clientId, clientSecret)
-}
-
-function logError(log, error) {
-	throw new ClientError(error)
 }
 
 exports.refreshToken = function (url, clientId, clientSecret, refreshToken) {


### PR DESCRIPTION
Corrects a fairly serious problem where asynchronous API requests (i.e. those not in response to lifecycle events) that encountered errors other than 401 errors would not clear the semaphore used to serialize requests and therefore cause failures of subsequent operations during the same app invocation.

Note that this serialization is done so that concurrent requests that encounter expired auth tokens and trigger an automatic refresh don't step on one another and result in the persistence of an expired refresh token (since we change the refresh token with each request).

This serialization only applies to current API requests made during a single app invocation so it isn't a guarantee against corrupted refresh tokens, but it at least reduces the probability of that occurring. If SmartThings should every change the policy of changing the refresh token with each refresh, this serialization logic could be changed or removed.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
