### PR TITLE
fix: Corrected bug in automatic refresh of tokens

### DIFF
--- a/lib/platform/client.js
+++ b/lib/platform/client.js
@@ -121,7 +121,6 @@ exports.refreshToken = function (url, clientId, clientSecret, refreshToken) {
 	const opts = {
 		url,
 		method: 'POST',
-		resolveWithFullResponse: true,
 		headers: {
 			'Content-Type': 'application/x-www-form-urlencoded',
 			'Authorization': 'Basic ' + Buffer.from(`${clientId}:${clientSecret}`, 'ascii').toString('base64')

--- a/lib/util/smart-app-context.js
+++ b/lib/util/smart-app-context.js
@@ -128,7 +128,7 @@ module.exports = class SmartAppContext {
 				this.locationId = data.locationId
 				this.api = new SmartThingsApi({
 					authToken: data.authToken,
-					refreshToken: data.authToken,
+					refreshToken: data.refreshToken,
 					clientId: app._clientId,
 					clientSecret: app._clientSecret,
 					log: app._log,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/smartapp",
-  "version": "1.13.2",
+  "version": "1.13.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12154,7 +12154,6 @@
                 "debug": "^3.1.0",
                 "get-uri": "^2.0.0",
                 "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent-snyk-fork": "git://github.com/snyk/node-https-proxy-agent.git#fix/https-agent-vuln",
                 "pac-resolver": "^3.0.0",
                 "raw-body": "^2.2.0",
                 "socks-proxy-agent": "^4.0.1"


### PR DESCRIPTION
Fixed regression in automatic refreshing of tokens from asynchronous calls to the SmartThings platform (that is, calls not in response to lifecycle events).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
