### PR TITLE
fix: Log responses as well as events for lambdas as is done for webhooks

### DIFF
--- a/lib/util/responders.js
+++ b/lib/util/responders.js
@@ -23,6 +23,7 @@ class LambdaResponder {
 	}
 
 	respond(data) {
+		this._log.response(data)
 		this._callback(null, data)
 	}
 }
@@ -33,6 +34,7 @@ class MockResponder {
 	}
 
 	respond(data) {
+		this._log.response(data)
 		this.response = data
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/smartapp",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The `enableEventLogging` configuration flag logs lifecycle event requests as well a the responses in the http handler for web-hook apps, but logged only the requests for Lambdas. This change logs both for all handlers.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] Any required documentation has been added
- [ ] I have added tests to cover my changes
