### PR TITLE
fix: applied translateDefaultValue to SectionSettings

### DIFF
--- a/doc/pages.md
+++ b/doc/pages.md
@@ -91,6 +91,7 @@ The following properties can be set for any type of setting
 ##### _disabled (true|false)_
 ##### _required (true|false)_
 ##### _defaultValue (value)_
+##### _translateDefaultValue (true|false)_
 
 #### booleanSetting (id)
 ##### _image (url)_

--- a/lib/pages/section-setting.js
+++ b/lib/pages/section-setting.js
@@ -12,6 +12,8 @@ module.exports = class SectionSetting {
 		} else if (id) {
 			section._page._settingIds.push(id)
 		}
+
+		this._translateDefaultValue = false
 	}
 
 	name(value) {
@@ -24,6 +26,15 @@ module.exports = class SectionSetting {
 			this._description = ''
 		} else {
 			this._description = value
+		}
+
+		return this
+	}
+
+	translateDefaultValue(value) {
+		this._translateDefaultValue = value
+		if (value === true) {
+			this._defaultValue = this.i18nKey('defaultValue')
 		}
 
 		return this
@@ -76,7 +87,9 @@ module.exports = class SectionSetting {
 			result.description = this.translate(this._description)
 		}
 
-		if (this._defaultValue !== undefined) {
+		if (this._translateDefaultValue && (typeof (this._defaultValue) === 'string' || this._defaultValue instanceof String)) {
+			result.defaultValue = this.translate(this._defaultValue)
+		} else if (this._defaultValue !== undefined) {
 			result.defaultValue = this._defaultValue
 		}
 


### PR DESCRIPTION
<!-- Describe your pull request. -->
Previous PR #127 broke the behavior of `textSetting` that was showing nothing properly when the `defaultValue` was not specified. To restore that break, I've added `translatedDefaultValue()` to handle only the case of using locales.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [ ] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] Any required documentation has been added
- [ ] I have added tests to cover my changes
