### PR TITLE
feat: Return executeData in response to EXECUTE lifecycle event

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -748,6 +748,16 @@ module.exports = class SmartApp {
 		return this
 	}
 
+	/**
+	 * Handler for execute events
+	 * @param {Object} callback handler
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	executeHandler(callback) {
+		this._executeHandler = callback
+		return this
+	}
+
 	/// //////////////
 	// Utilities   //
 	/// //////////////
@@ -1099,7 +1109,8 @@ module.exports = class SmartApp {
 
 				case 'EXECUTE': {
 					this._log.event(evt)
-					await this._executeHandler(context, evt.executeData)
+					const executeData = (await this._executeHandler(context, evt.executeData)) || {}
+					responder.respond({statusCode: 200, executeData})
 					break
 				}
 

--- a/test/unit/events/execute-event-spec.js
+++ b/test/unit/events/execute-event-spec.js
@@ -1,0 +1,110 @@
+/* eslint no-undef: 'off' */
+const assert = require('assert').strict
+const SmartApp = require('../../../lib/smart-app')
+
+describe('execute-event-spec', () => {
+	/** @type {SmartApp} */
+	let app
+	let receivedEvent
+
+	beforeEach(() => {
+		app = new SmartApp({logUnhandledRejections: false})
+	})
+
+	it('should handle EXECUTE lifecycle', async () => {
+		const expectedEvent = {
+			'authToken': 'xxxxx',
+			'installedApp': {
+				'installedAppId': 'd692699d-e7a6-400d-a0b7-d5be96e7a564',
+				'locationId': 'e675a3d9-2499-406c-86dc-8a492a886494',
+				'config': {
+					'contactSensor': [
+						{
+							'valueType': 'DEVICE',
+							'deviceConfig': {
+								'deviceId': 'e457978e-5e37-43e6-979d-18112e12c961',
+								'componentId': 'main'
+							}
+						}
+					],
+					'lightSwitch': [
+						{
+							'valueType': 'DEVICE',
+							'deviceConfig': {
+								'deviceId': '74aac3bb-91f2-4a88-8c49-ae5e0a234d76',
+								'componentId': 'main'
+							}
+						}
+					]
+				},
+				'permissions': [
+					'r:devices:e457978e-5e37-43e6-979d-18112e12c961',
+					'x:devices:74aac3bb-91f2-4a88-8c49-ae5e0a234d76'
+				]
+			},
+			'parameters': {
+				'property1': 'Property 1 value',
+				'property2': 'Property 2 value'
+			}
+		}
+		const expectedResponse = {
+			statusCode: 200,
+			executeData: {
+				item1: 'Returned value 1',
+				item2: 'Returned value 2'
+			}
+		}
+		app.executeHandler((_, event) => {
+			receivedEvent = event
+			return {
+				item1: 'Returned value 1',
+				item2: 'Returned value 2'
+			}
+		})
+		const response = await app.handleMockCallback({
+			'lifecycle': 'EXECUTE',
+			'executionId': 'b328f242-c602-4204-8d73-33c48ae180af',
+			'appId': '9871bcc7-36d8-4b5a-ad46-de1645b8ff3e',
+			'locale': 'en',
+			'executeData': {
+				'authToken': 'xxxxx',
+				'installedApp': {
+					'installedAppId': 'd692699d-e7a6-400d-a0b7-d5be96e7a564',
+					'locationId': 'e675a3d9-2499-406c-86dc-8a492a886494',
+					'config': {
+						'contactSensor': [
+							{
+								'valueType': 'DEVICE',
+								'deviceConfig': {
+									'deviceId': 'e457978e-5e37-43e6-979d-18112e12c961',
+									'componentId': 'main'
+								}
+							}
+						],
+						'lightSwitch': [
+							{
+								'valueType': 'DEVICE',
+								'deviceConfig': {
+									'deviceId': '74aac3bb-91f2-4a88-8c49-ae5e0a234d76',
+									'componentId': 'main'
+								}
+							}
+						]
+					},
+					'permissions': [
+						'r:devices:e457978e-5e37-43e6-979d-18112e12c961',
+						'x:devices:74aac3bb-91f2-4a88-8c49-ae5e0a234d76'
+					]
+				},
+				'parameters': {
+					'property1': 'Property 1 value',
+					'property2': 'Property 2 value'
+				}
+			},
+			'settings': {}
+		})
+
+		assert.deepStrictEqual(receivedEvent, expectedEvent)
+		assert.deepStrictEqual(response, expectedResponse)
+	})
+})


### PR DESCRIPTION
Add support for handling execute lifecycle events and returning a response. Addresses issue #121 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
