### PR TITLE
feat: Removed auto-confirmation for API Access apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ Available as a node package on [NPM](https://www.npmjs.com/package/@smartthings/
 See the full usage guide on the project's GitHub repository. ([SmartThingsCommunity/firestore-context-store-nodejs](https://github.com/SmartThingsCommunity/firestore-context-store-nodejs#usage))
 
 ---
-
 ## More about SmartThings
 
 If you are not familiar with SmartThings, we have

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -3,7 +3,6 @@
 const i18n = require('i18n')
 const fs = require('fs-extra')
 const {Mutex} = require('async-mutex')
-const rp = require('request-promise-native')
 
 const Authorizer = require('./util/authorizer')
 const responders = require('./util/responders')
@@ -1104,15 +1103,18 @@ module.exports = class SmartApp {
 				}
 
 				case 'CONFIRMATION': {
-					if (evt.confirmationData && evt.confirmationData.confirmationUrl) {
-						try {
-							await rp.get(evt.confirmationData.confirmationUrl)
-							this._log.info(`App ${evt.confirmationData.appId} callback confirmed`)
-							responder.respond({statusCode: 200})
-						} catch (error) {
-							this._log.error(error.message || error)
-							responder.respond({statusCode: error.statusCode || 500, message: error.message || error})
+					if (evt.confirmationData && evt.confirmationData.appId && evt.confirmationData.confirmationUrl) {
+						if (this._id) {
+							if (evt.confirmationData.appId === this._id) {
+								this._log.info(`CONFIRMATION request for app ${evt.confirmationData.appId}, to enable events visit ${evt.confirmationData.confirmationUrl}`)
+							} else {
+								this._log.warn(`Unexpected CONFIRMATION request for app ${evt.confirmationData.appId}, received ${JSON.stringify(evt)}`)
+							}
+						} else {
+							this._log.info(`CONFIRMATION request for app ${evt.confirmationData.appId}, to enable events visit ${evt.confirmationData.confirmationUrl}`)
 						}
+					} else {
+						this._log.warn(`Invalid CONFIRMATION request ${JSON.stringify(evt)}`)
 					}
 
 					break

--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -39,9 +39,9 @@ module.exports = class Log {
 	event(evt, suffix = '') {
 		if (this._eventsEnabled) {
 			try {
-				this._logger.log('debug', `${evt.lifecycle}${suffix ? `/${suffix}` : ''} REQUEST: ${JSON.stringify(evt, null, this._jsonSpace)}`)
+				this._logger.log('debug', `${evt.lifecycle || evt.messageType}${suffix ? `/${suffix}` : ''} REQUEST: ${JSON.stringify(evt, null, this._jsonSpace)}`)
 			} catch (error) {
-				this._logger.log('error', `${evt.lifecycle}${suffix ? `/${suffix}` : ''} Error logging request: ${error}`)
+				this._logger.log('error', `${evt.lifecycle || evt.messageType}${suffix ? `/${suffix}` : ''} Error logging request: ${error}`)
 			}
 		}
 	}

--- a/test/unit/events/confirmation-spec.js
+++ b/test/unit/events/confirmation-spec.js
@@ -1,20 +1,12 @@
 /* eslint no-undef: 'off' */
 const {expect} = require('chai')
-const rp = require('request-promise-native')
 const sinon = require('sinon')
 const SmartApp = require('../../../lib/smart-app')
 
 describe('confirmation-spec', () => {
-	/** @type {SmartApp} */
-	let app
-
-	beforeEach(() => {
-		app = new SmartApp({logUnhandledRejections: false})
-	})
-
-	it('confirmation message', () => {
-		const stub = sinon.stub(rp, 'get')
-
+	it('auto confirmation default (disabled)', () => {
+		const app = new SmartApp({logUnhandledRejections: false})
+		const stub = sinon.stub(app._log, 'info')
 		app.handleMockCallback({
 			'messageType': 'CONFIRMATION',
 			'confirmationData': {
@@ -24,5 +16,57 @@ describe('confirmation-spec', () => {
 		})
 
 		expect(stub.calledOnce).to.equal(true)
+		expect(stub.calledWith('CONFIRMATION request for app f9a665e7-5a76-4b1e-bdfe-31135eccc2f3, to enable events visit https://api.smartthings.com/apps/f9a665e7-5a76-4b1e-bdfe-31135eccc2f3/confirm-registration?token=fd9581b5-628c-4cd7-b1c2-dc14761234f3')).to.equal(true)
+		stub.restore()
+	})
+
+	it('auto confirmation enabled', () => {
+		const app = new SmartApp({logUnhandledRejections: false, appId: 'f9a665e7-5a76-4b1e-bdfe-31135eccc2f3'})
+		const stub = sinon.stub(app._log, 'info')
+		app.handleMockCallback({
+			'messageType': 'CONFIRMATION',
+			'confirmationData': {
+				'appId': 'f9a665e7-5a76-4b1e-bdfe-31135eccc2f3',
+				'confirmationUrl': 'https://api.smartthings.com/apps/f9a665e7-5a76-4b1e-bdfe-31135eccc2f3/confirm-registration?token=fd9581b5-628c-4cd7-b1c2-dc14761234f3'
+			}
+		})
+
+		expect(stub.calledOnce).to.equal(true)
+		expect(stub.calledWith('CONFIRMATION request for app f9a665e7-5a76-4b1e-bdfe-31135eccc2f3, to enable events visit https://api.smartthings.com/apps/f9a665e7-5a76-4b1e-bdfe-31135eccc2f3/confirm-registration?token=fd9581b5-628c-4cd7-b1c2-dc14761234f3')).to.equal(true)
+		stub.restore()
+	})
+
+	it('auto confirmation enabled, wrong appId', () => {
+		const app = new SmartApp({logUnhandledRejections: false, appId: 'f9a665e7-5a76-4b1e-bdfe-31135ecccdef'})
+		const stub = sinon.stub(app._log, 'warn')
+		const body = {
+			'messageType': 'CONFIRMATION',
+			'confirmationData': {
+				'appId': 'f9a665e7-5a76-4b1e-bdfe-31135eccc2f3',
+				'confirmationUrl': 'https://api.smartthings.com/apps/f9a665e7-5a76-4b1e-bdfe-31135eccc2f3/confirm-registration?token=fd9581b5-628c-4cd7-b1c2-dc14761234f3'
+			}
+		}
+		app.handleMockCallback(body)
+
+		expect(stub.calledOnce).to.equal(true)
+		expect(stub.calledWith(`Unexpected CONFIRMATION request for app f9a665e7-5a76-4b1e-bdfe-31135eccc2f3, received ${JSON.stringify(body)}`)).to.equal(true)
+		stub.restore()
+	})
+
+	it('invalid confirmation event', () => {
+		const app = new SmartApp({logUnhandledRejections: false, appId: 'f9a665e7-5a76-4b1e-bdfe-31135ecccdef'})
+		const stub = sinon.stub(app._log, 'warn')
+		const body = {
+			'messageType': 'CONFIRMATION',
+			'confirmationData': {
+				'otherId': 'f9a665e7-5a76-4b1e-bdfe-31135eccc2f3',
+				'confirmationUrl': 'https://api.smartthings.com/apps/f9a665e7-5a76-4b1e-bdfe-31135eccc2f3/confirm-registration?token=fd9581b5-628c-4cd7-b1c2-dc14761234f3'
+			}
+		}
+		app.handleMockCallback(body)
+
+		expect(stub.calledOnce).to.equal(true)
+		expect(stub.calledWith(`Invalid CONFIRMATION request ${JSON.stringify(body)}`)).to.equal(true)
+		stub.restore()
 	})
 })


### PR DESCRIPTION
Removed auto-confirmation of API Access app target URLs as it is a security issue. Addresses issue #139 

Note that while not a breaking change to the functionality of an API Access app that has already been deployed, this change does affect the app development process in that the app will no longer automatically response to a registration request and therefore the callbacks state will remain PENDING until the user visits the URL printed to the server log.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
