### PR TITLE
fix: Construct proper authenticator type

### DIFF
--- a/lib/util/smart-app-context.js
+++ b/lib/util/smart-app-context.js
@@ -1,7 +1,12 @@
 'use strict'
 
 const i18n = require('i18n')
-const {SmartThingsClient, SequentialRefreshTokenAuthenticator} = require('@smartthings/core-sdk')
+const {
+	SmartThingsClient,
+	BearerTokenAuthenticator,
+	RefreshTokenAuthenticator,
+	SequentialRefreshTokenAuthenticator} = require('@smartthings/core-sdk')
+
 const TokenStore = require('./token-store')
 
 module.exports = class SmartAppContext {
@@ -87,11 +92,25 @@ module.exports = class SmartAppContext {
 		}
 
 		if (this.authToken) {
-			const authenticator = new SequentialRefreshTokenAuthenticator(
-				this.authToken,
-				new TokenStore(this.installedAppId, app._contextStore, app._clientId, app._clientSecret),
-				this.apiMutex
-			)
+			const authenticator = app._contextStore ?
+				(this.apiMutex ?
+
+					// Authenticator for non-lifecycle invocations which forces refresh requests to be
+					// sequential to reduce the chance of overwriting a valid refresh token with an
+					// invalid one
+					new SequentialRefreshTokenAuthenticator(
+						this.authToken,
+						new TokenStore(this.installedAppId, app._contextStore, app._clientId, app._clientSecret),
+						this.apiMutex) :
+
+					// Not currently used by the SDK but here for logical consistency in case a path is added that
+					// supports parallel refreshes
+					new RefreshTokenAuthenticator(this.authToken,
+						new TokenStore(this.installedAppId, app._contextStore, app._clientId, app._clientSecret))) :
+
+				// Authenticator for lifecycle event invocations. Refresh unnecessary since token is always valid
+				new BearerTokenAuthenticator(this.authToken)
+
 			const config = {
 				locationId: this.locationId,
 				installedAppId: this.installedAppId

--- a/test/unit/smartapp-context-spec.js
+++ b/test/unit/smartapp-context-spec.js
@@ -2,6 +2,9 @@
 
 const assert = require('assert').strict
 const {expect} = require('chai')
+const {
+	BearerTokenAuthenticator,
+	SequentialRefreshTokenAuthenticator} = require('@smartthings/core-sdk')
 const SmartApp = require('../../lib/smart-app')
 const SmartAppContext = require('../../lib/util/smart-app-context')
 
@@ -75,8 +78,9 @@ describe('smartapp-context-spec', () => {
 		})
 
 		const ctx = await app.withContext('d692699d-e7a6-400d-a0b7-d5be96e7a564')
-		expect(ctx).to.be.instanceof(SmartAppContext)
 
+		expect(ctx).to.be.instanceof(SmartAppContext)
+		expect(ctx.api.config.authenticator).to.be.instanceof(SequentialRefreshTokenAuthenticator)
 		assert.equal(installData.installedApp.installedAppId, ctx.installedAppId)
 		assert.equal(installData.installedApp.locationId, ctx.locationId)
 		assert.equal(installData.authToken, ctx.authToken)
@@ -86,7 +90,6 @@ describe('smartapp-context-spec', () => {
 	it('endpoint app with context object', async () => {
 		const params = {
 			authToken: 'xxx',
-			refreshToken: 'yyy',
 			installedAppId: 'aaa',
 			locationId: 'bbb',
 			locale: 'en',
@@ -95,14 +98,17 @@ describe('smartapp-context-spec', () => {
 
 		const ctx = await app.withContext(params)
 
+		expect(ctx.api.config.authenticator).to.be.instanceof(BearerTokenAuthenticator)
 		assert.equal(params.installedAppId, ctx.installedAppId)
 		assert.equal(params.locationId, ctx.locationId)
 		assert.equal(params.authToken, ctx.authToken)
-		assert.equal(params.refreshToken, ctx.refreshToken)
 		assert.equal(params.locale, ctx.event.locale)
 	})
 
 	it('api app with context object', async () => {
+		const contextStore = new ContextStore()
+		app.contextStore(contextStore)
+
 		const params = {
 			authToken: 'xxx',
 			refreshToken: 'yyy',
@@ -112,6 +118,7 @@ describe('smartapp-context-spec', () => {
 
 		const ctx = await app.withContext(params)
 
+		expect(ctx.api.config.authenticator).to.be.instanceof(SequentialRefreshTokenAuthenticator)
 		assert.equal(params.installedAppId, ctx.installedAppId)
 		assert.equal(params.locationId, ctx.locationId)
 		assert.equal(params.authToken, ctx.authToken)


### PR DESCRIPTION
Construct proper authenticator type depending on whether a context store and mutex for sequential refreshes is defined.
Previously a sequential refresh authenticator was being constructed with potentially undefined values for the context store,
which resulted in unexpected exceptions from the core API in some cases

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
