### PR TITLE
fix: log missing event handlers

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -587,6 +587,7 @@ class SmartApp {
 									results.push(handler(context, event.deviceEvent, event.eventTime))
 									break
 								} else {
+									this._log.error(`Device event handler '${handlerName}' not defined`)
 									responder.respond({statusCode: 422, eventData: {}})
 									return
 								}
@@ -599,6 +600,7 @@ class SmartApp {
 									results.push(handler(context, event.timerEvent, event.eventTime))
 									break
 								} else {
+									this._log.error(`Timer event handler '${handlerName}' not defined`)
 									responder.respond({statusCode: 422, eventData: {}})
 									return
 								}
@@ -636,6 +638,7 @@ class SmartApp {
 									results.push(handler(context, event.deviceLifecycleEvent, event.eventTime))
 									break
 								} else {
+									this._log.error(`Device lifecycle event handler '${handlerName}' not defined`)
 									responder.respond({statusCode: 422, eventData: {}})
 									return
 								}
@@ -649,6 +652,7 @@ class SmartApp {
 									results.push(handler(context, event.deviceHealthEvent, event.eventTime))
 									break
 								} else {
+									this._log.error(`Device health event handler '${handlerName}' not defined`)
 									responder.respond({statusCode: 422, eventData: {}})
 									return
 								}
@@ -662,6 +666,7 @@ class SmartApp {
 									results.push(handler(context, event.hubHealthEvent, event.eventTime))
 									break
 								} else {
+									this._log.error(`Hub health event handler '${handlerName}' not defined`)
 									responder.respond({statusCode: 422, eventData: {}})
 									return
 								}
@@ -675,6 +680,7 @@ class SmartApp {
 									results.push(handler(context, event.modeEvent, event.eventTime))
 									break
 								} else {
+									this._log.error(`Mode event handler '${handlerName}' not defined`)
 									responder.respond({statusCode: 422, eventData: {}})
 									return
 								}
@@ -688,6 +694,7 @@ class SmartApp {
 									results.push(handler(context, event.securityArmStateEvent, event.eventTime))
 									break
 								} else {
+									this._log.error(`Security arm state event handler '${handlerName}' not defined`)
 									responder.respond({statusCode: 422, eventData: {}})
 									return
 								}
@@ -701,6 +708,7 @@ class SmartApp {
 									results.push(handler(context, event.sceneLifecycleEvent, event.eventTime))
 									break
 								} else {
+									this._log.error(`Scene lifecycle event handler '${handlerName}' not defined`)
 									responder.respond({statusCode: 422, eventData: {}})
 									return
 								}


### PR DESCRIPTION
Earlier fix to properly return 422 error for missing event handlers had the side-effect of giving no indication in the server logs
as to which handler was missing. Added logging to provide this indication

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
