### PR TITLE
fix: Add await to context store put operations

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -427,7 +427,7 @@ class SmartApp {
 		ctx.setLocationId(isa.locationId)
 
 		if (this._contextStore) {
-			this._contextStore.put({
+			await this._contextStore.put({
 				installedAppId: ctx.installedAppId,
 				locationId: ctx.locationId,
 				authToken: auth.access_token,
@@ -540,7 +540,7 @@ class SmartApp {
 					this._log.event(evt)
 					await this._installedHandler(context, evt.installData)
 					if (this._contextStore) {
-						this._contextStore.put({
+						await this._contextStore.put({
 							installedAppId: context.installedAppId,
 							locationId: context.locationId,
 							authToken: context.authToken,
@@ -559,7 +559,7 @@ class SmartApp {
 					this._log.event(evt)
 					await this._updatedHandler(context, evt.updateData)
 					if (this._contextStore) {
-						this._contextStore.put({
+						await this._contextStore.put({
 							installedAppId: context.installedAppId,
 							locationId: context.locationId,
 							authToken: context.authToken,


### PR DESCRIPTION
Add `await` to context store `put` operations so that failures can be properly handled in the app. Addresses issue #165 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
