### PR TITLE
test(text-setting): add initial coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,11 +103,14 @@
     },
     "overrides": [
       {
-        "files": "examples/**/*.js",
+        "files": "test/**",
         "rules": {
-          "import/no-unresolved": 0
+          "prefer-arrow-callback": 0
         }
       }
+    ],
+    "envs": [
+      "mocha"
     ]
   },
   "snyk": false

--- a/test/unit/pages/boolean-setting-spec.js
+++ b/test/unit/pages/boolean-setting-spec.js
@@ -1,4 +1,3 @@
-/* eslint no-undef: "off" */
 const {expect} = require('chai')
 const Page = require('../../../lib/pages/page')
 const Section = require('../../../lib/pages/section')

--- a/test/unit/pages/device-setting-spec.js
+++ b/test/unit/pages/device-setting-spec.js
@@ -1,4 +1,3 @@
-/* eslint no-undef: "off" */
 const {expect} = require('chai')
 const Page = require('../../../lib/pages/page')
 const Section = require('../../../lib/pages/section')

--- a/test/unit/pages/enum-setting-spec.js
+++ b/test/unit/pages/enum-setting-spec.js
@@ -1,4 +1,3 @@
-/* eslint no-undef: "off" */
 const path = require('path')
 const i18n = require('i18n')
 const {expect} = require('chai')

--- a/test/unit/pages/section-setting-spec.js
+++ b/test/unit/pages/section-setting-spec.js
@@ -1,4 +1,3 @@
-/* eslint no-undef: "off" */
 const {expect} = require('chai')
 const Page = require('../../../lib/pages/page')
 const Section = require('../../../lib/pages/section')

--- a/test/unit/pages/text-setting-spec.js
+++ b/test/unit/pages/text-setting-spec.js
@@ -1,0 +1,60 @@
+const {expect} = require('chai')
+const Page = require('../../../lib/pages/page')
+const Section = require('../../../lib/pages/section')
+const TextSetting = require('../../../lib/pages/text-setting')
+
+describe('text-setting', function () {
+	let page = {}
+	let section = {}
+
+	beforeEach(() => {
+		page = new Page('testPage')
+		section = new Section(page, 'testSection')
+	})
+
+	it('should set type to text', function () {
+		const textSetting = new TextSetting(section, 'text').toJson()
+		expect(textSetting.type).to.equal('TEXT')
+	})
+
+	it('should set default description', function () {
+		const textSetting = new TextSetting(section, 'text').toJson()
+		expect(textSetting.description).to.equal('Tap to set')
+	})
+
+	it('should set maxLength when specified', function () {
+		const maxLength = 9
+		const textSetting = new TextSetting(section, 'text')
+			.maxLength(maxLength)
+			.toJson()
+
+		expect(textSetting.maxLength).to.equal(maxLength)
+	})
+
+	it('should set minLength when specified', function () {
+		const minLength = 1
+		const textSetting = new TextSetting(section, 'text')
+			.minLength(minLength)
+			.toJson()
+
+		expect(textSetting.minLength).to.equal(minLength)
+	})
+
+	it('should set image when specified', function () {
+		const imageUrl = 'https://test.local/image.png'
+		const textSetting = new TextSetting(section, 'text')
+			.image(imageUrl)
+			.toJson()
+
+		expect(textSetting.image).to.equal(imageUrl)
+	})
+
+	it('should set postMessage when specified', function () {
+		const postMessage = 'test'
+		const textSetting = new TextSetting(section, 'text')
+			.postMessage(postMessage)
+			.toJson()
+
+		expect(textSetting.postMessage).to.equal(postMessage)
+	})
+})

--- a/test/unit/util/authorizer-spec.js
+++ b/test/unit/util/authorizer-spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef, no-unused-expressions */
+/* eslint-disable no-unused-expressions */
 const fs = require('fs')
 const path = require('path')
 const nock = require('nock')

--- a/test/unit/util/configuration-error-spec.js
+++ b/test/unit/util/configuration-error-spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef, no-unused-expressions */
+/* eslint-disable no-unused-expressions */
 const {expect} = require('chai')
 const ConfigurationError = require('../../../lib/util/configuration-error')
 

--- a/test/unit/util/endpoint-context-spec.js
+++ b/test/unit/util/endpoint-context-spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef, no-unused-expressions */
+/* eslint-disable no-unused-expressions */
 const chai = require('chai')
 const EndpointContext = require('../../../lib/util/smart-app-context')
 const SmartApp = require('../../../lib/smart-app')

--- a/test/unit/util/log-spec.js
+++ b/test/unit/util/log-spec.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef, no-unused-expressions */
+/* eslint-disable no-unused-expressions */
 const sinon = require('sinon')
 const {expect} = require('chai')
 const Log = require('../../../lib/util/log')


### PR DESCRIPTION
* disable `prefer-arrow-callback` rule for tests, as mocha [discourages arrows](https://mochajs.org/#arrow-functions) in some cases
* add `mocha` env to `xo` config so that linting is aware of `describe` in tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
