### PR TITLE
fix: Add Accept-Language to API calls when locale is set

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -420,7 +420,8 @@ class SmartApp {
 		const ctx = await this.withContext({
 			installedAppId: auth.installed_app_id,
 			authToken: auth.access_token,
-			refreshToken: auth.refresh_token
+			refreshToken: auth.refresh_token,
+			locale: request.headers ? request.headers['Accept-Language'] : undefined
 		})
 
 		const isa = await ctx.api.installedApps.get(auth.installed_app_id)

--- a/lib/util/smart-app-context.js
+++ b/lib/util/smart-app-context.js
@@ -115,6 +115,13 @@ module.exports = class SmartAppContext {
 				locationId: this.locationId,
 				installedAppId: this.installedAppId
 			}
+
+			if (this.locale) {
+				config.headers = {
+					'Accept-Language': this.locale
+				}
+			}
+
 			if (app._apiUrl) {
 				config.urlProvider = {
 					baseURL: app._apiUrl,
@@ -158,6 +165,13 @@ module.exports = class SmartAppContext {
 					locationId: this.locationId,
 					installedAppId: this.installedAppId
 				}
+
+				if (this.locale) {
+					config.headers = {
+						'Accept-Language': this.locale
+					}
+				}
+
 				if (app._apiUrl) {
 					config.urlProvider = {
 						baseURL: app._apiUrl,

--- a/test/unit/smartapp-context-spec.js
+++ b/test/unit/smartapp-context-spec.js
@@ -122,4 +122,18 @@ describe('smartapp-context-spec', () => {
 		assert.equal(params.refreshToken, ctx.refreshToken)
 		assert.equal(params.locale, ctx.event.locale)
 	})
+
+	it('accept-language header in API calls', async () => {
+		const params = {
+			authToken: 'xxx',
+			installedAppId: 'aaa',
+			locationId: 'bbb',
+			locale: 'es',
+			config: {device: 'ccc'}
+		}
+
+		const ctx = await app.withContext(params)
+
+		expect(ctx.api.config.headers['Accept-Language']).toBe('es')
+	})
 })


### PR DESCRIPTION
Pass locale, if set, in the Accept-Language header of API requests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
