### PR TITLE
feat: Added optional handler for CONFIGURATION/INITIALIZE event

### DIFF
--- a/docs/classes/_smart_app_d_.smartapp.md
+++ b/docs/classes/_smart_app_d_.smartapp.md
@@ -57,6 +57,7 @@ Name | Type | Description |
 * [handleLambdaCallback](_smart_app_d_.smartapp.md#handlelambdacallback)
 * [handleMockCallback](_smart_app_d_.smartapp.md#handlemockcallback)
 * [handleOAuthCallback](_smart_app_d_.smartapp.md#handleoauthcallback)
+* [initialized](_smart_app_d_.smartapp.md#initialized)
 * [installed](_smart_app_d_.smartapp.md#installed)
 * [keyApiHost](_smart_app_d_.smartapp.md#keyapihost)
 * [oauthHandler](_smart_app_d_.smartapp.md#oauthhandler)
@@ -502,6 +503,31 @@ Name | Type |
 `request` | [WebHookRequest](../interfaces/_smart_app_d_.webhookrequest.md) |
 
 **Returns:** *Promise‹[ContextRecord](../interfaces/_smart_app_d_.contextrecord.md)›*
+
+___
+
+###  initialized
+
+▸ **initialized**(`callback`: function): *[SmartApp](_smart_app_d_.smartapp.md)*
+
+Defines a handler to be called the first time a SmartApp is installed. If not specified then the
+`updated()` handler will be called on the initial installation as well as updates.
+
+**Parameters:**
+
+▪ **callback**: *function*
+
+▸ (`context`: [SmartAppContext](../interfaces/_util_smart_app_context_d_.smartappcontext.md), `initialization`: [Initialization](_util_initialization_d_.initialization.md), `configData`: [ConfigurationData](../modules/_lifecycle_events_d_.md#configurationdata)): *[HandlerResponse](../modules/_smart_app_d_.md#handlerresponse)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`context` | [SmartAppContext](../interfaces/_util_smart_app_context_d_.smartappcontext.md) |
+`initialization` | [Initialization](_util_initialization_d_.initialization.md) |
+`configData` | [ConfigurationData](../modules/_lifecycle_events_d_.md#configurationdata) |
+
+**Returns:** *[SmartApp](_smart_app_d_.smartapp.md)*
 
 ___
 

--- a/lib/smart-app.d.ts
+++ b/lib/smart-app.d.ts
@@ -18,6 +18,7 @@ import DeviceCommandsEvent = AppEvent.DeviceCommandsEvent;
 import SecurityArmStateEvent = AppEvent.SecurityArmStateEvent;
 import ExecuteData = AppEvent.ExecuteData;
 import UninstallData = AppEvent.UninstallData;
+import {Initialization} from './util/initialization'
 
 /**
  * Configuration options for SmartApps. These can either be passed into the constructor
@@ -387,6 +388,16 @@ export class SmartApp {
      * Defines a handler to be called the first time a SmartApp is installed. If not specified then the
      * `updated()` handler will be called on the initial installation as well as updates.
      */
+    initialized(callback: (
+        context: SmartAppContext,
+        initialization: Initialization,
+        configData: AppEvent.ConfigurationData) =>
+        HandlerResponse): SmartApp
+
+    /**
+     * Defines a handler to be called the first time a SmartApp is installed. If not specified then the
+     * `updated()` handler will be called on the initial installation as well as updates.
+     */
     installed(callback: (context: SmartAppContext, installData: AppEvent.InstallData) => HandlerResponse): SmartApp
 
     /**
@@ -418,7 +429,7 @@ export class SmartApp {
      * explicitly required by this app. For example `['r:devices:*', and 'x:devices:*']
      * to be able to read and control all devices in the location. You do not have to
      * provide this list for devices selected by the user in configuration settings.
-     * 
+     *
      * If permissions are specified, [[appId]] is also required.
      */
     permissions(value: string | string[]): SmartApp

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -8,6 +8,7 @@ const Authorizer = require('./util/authorizer')
 const responders = require('./util/responders')
 const SmartAppContext = require('./util/smart-app-context')
 const Page = require('./pages/page')
+const Initialization = require('./util/initialization')
 const Log = require('./util/log')
 const ConfigurationError = require('./util/configuration-error')
 
@@ -39,6 +40,7 @@ class SmartApp {
 			})
 			this._log.warn(msg)
 		})
+		this._initializedHandler = null
 		this._installedHandler = ((ctx, installData) => {
 			this._updatedHandler(ctx, installData)
 		})
@@ -166,6 +168,15 @@ class SmartApp {
 
 	firstPageId(pageId) {
 		this._firstPageId = pageId
+		return this
+	}
+
+	// /////////////////////////////
+	// Configuration/Initialize   //
+	// /////////////////////////////
+
+	initialized(callback) {
+		this._initializedHandler = callback
 		return this
 	}
 
@@ -491,15 +502,21 @@ class SmartApp {
 					switch (configurationData.phase) {
 						case 'INITIALIZE': {
 							this._log.event(evt, configurationData.phase)
+							const initialize = {
+								id: this._id,
+								firstPageId: this._firstPageId,
+								permissions: this._permissions,
+								disableCustomDisplayName: this._disableCustomDisplayName,
+								disableRemoveApp: this._disableRemoveApp
+							}
+
+							if (this._initializedHandler) {
+								await this._initializedHandler(context, new Initialization(initialize), configurationData)
+							}
+
 							responder.respond({
 								statusCode: 200, configurationData: {
-									initialize: {
-										id: this._id,
-										firstPageId: this._firstPageId,
-										permissions: this._permissions,
-										disableCustomDisplayName: this._disableCustomDisplayName,
-										disableRemoveApp: this._disableRemoveApp
-									}
+									initialize
 								}
 							})
 							break

--- a/lib/util/initialization.d.ts
+++ b/lib/util/initialization.d.ts
@@ -1,0 +1,6 @@
+export class Initialization {
+    firstPageId(value: string)
+    permissions(value: string | string[])
+    disableCustomDisplayName(value?: boolean)
+    disableRemoveApp(value?: boolean)
+}

--- a/lib/util/initialization.js
+++ b/lib/util/initialization.js
@@ -1,0 +1,27 @@
+'use strict'
+
+module.exports = class Initialization {
+	constructor(params) {
+		this._params = params
+	}
+
+	firstPageId(value) {
+		this._params.firstPageId = value
+		return this
+	}
+
+	permissions(value) {
+		this._params.permissions = value
+		return this
+	}
+
+	disableCustomDisplayName(value = true) {
+		this._params.disableCustomDisplayName = value
+		return this
+	}
+
+	disableRemoveApp(value = true) {
+		this._params.disableRemoveApp = value
+		return this
+	}
+}

--- a/test/unit/smartapp-initialize-spec.js
+++ b/test/unit/smartapp-initialize-spec.js
@@ -1,8 +1,7 @@
-const assert = require('assert').strict
 const SmartApp = require('../../lib/smart-app')
 
 describe('smartapp-initialize-spec', () => {
-	it('default handler', async () => {
+	test('default handler', async () => {
 		const app = new SmartApp()
 			.appId('xxx')
 			.firstPageId('page1')
@@ -39,10 +38,10 @@ describe('smartapp-initialize-spec', () => {
 			disableRemoveApp: true
 		}}
 
-		assert.deepStrictEqual(resp.configurationData, expectedInitResponse)
+		expect(resp.configurationData).toStrictEqual(expectedInitResponse)
 	})
 
-	it('default handler', async () => {
+	test('custom handler page', async () => {
 		const app = new SmartApp()
 			.appId('xxx')
 			.permissions(['r:devices:*'])
@@ -79,10 +78,10 @@ describe('smartapp-initialize-spec', () => {
 			disableRemoveApp: false
 		}}
 
-		assert.deepStrictEqual(resp.configurationData, expectedInitResponse)
+		expect(resp.configurationData).toStrictEqual(expectedInitResponse)
 	})
 
-	it('custom handler all', async () => {
+	test('custom handler all', async () => {
 		const app = new SmartApp()
 			.appId('xxx')
 			.firstPageId('page1')
@@ -125,6 +124,6 @@ describe('smartapp-initialize-spec', () => {
 			disableRemoveApp: false
 		}}
 
-		assert.deepStrictEqual(resp.configurationData, expectedInitResponse)
+		expect(resp.configurationData).toStrictEqual(expectedInitResponse)
 	})
 })

--- a/test/unit/smartapp-initialize-spec.js
+++ b/test/unit/smartapp-initialize-spec.js
@@ -1,0 +1,130 @@
+const assert = require('assert').strict
+const SmartApp = require('../../lib/smart-app')
+
+describe('smartapp-initialize-spec', () => {
+	it('default handler', async () => {
+		const app = new SmartApp()
+			.appId('xxx')
+			.firstPageId('page1')
+			.permissions(['r:devices:*'])
+			.disableCustomDisplayName(true)
+			.disableRemoveApp(true)
+
+		// Initialize configuration callback
+		const resp = await app.handleMockCallback({
+			lifecycle: 'CONFIGURATION',
+			executionId: 'e6903fe6-f88f-da69-4c12-e2802606ccbc',
+			locale: 'en',
+			version: '0.1.0',
+			client: {
+				os: 'ios',
+				version: '0.0.0',
+				language: 'en-US'
+			},
+			configurationData: {
+				installedAppId: '7d7fa36d-0ad9-4893-985c-6b75858e38e4',
+				phase: 'INITIALIZE',
+				pageId: '',
+				previousPageId: '',
+				config: {}
+			},
+			settings: {}
+		})
+
+		const expectedInitResponse = {initialize: {
+			id: 'xxx',
+			firstPageId: 'page1',
+			permissions: ['r:devices:*'],
+			disableCustomDisplayName: true,
+			disableRemoveApp: true
+		}}
+
+		assert.deepStrictEqual(resp.configurationData, expectedInitResponse)
+	})
+
+	it('default handler', async () => {
+		const app = new SmartApp()
+			.appId('xxx')
+			.permissions(['r:devices:*'])
+			.initialized((ctx, initialization) => {
+				initialization.firstPageId('page2A')
+			})
+
+		// Initialize configuration callback
+		const resp = await app.handleMockCallback({
+			lifecycle: 'CONFIGURATION',
+			executionId: 'e6903fe6-f88f-da69-4c12-e2802606ccbc',
+			locale: 'en',
+			version: '0.1.0',
+			client: {
+				os: 'ios',
+				version: '0.0.0',
+				language: 'en-US'
+			},
+			configurationData: {
+				installedAppId: '7d7fa36d-0ad9-4893-985c-6b75858e38e4',
+				phase: 'INITIALIZE',
+				pageId: '',
+				previousPageId: '',
+				config: {}
+			},
+			settings: {}
+		})
+
+		const expectedInitResponse = {initialize: {
+			id: 'xxx',
+			firstPageId: 'page2A',
+			permissions: ['r:devices:*'],
+			disableCustomDisplayName: false,
+			disableRemoveApp: false
+		}}
+
+		assert.deepStrictEqual(resp.configurationData, expectedInitResponse)
+	})
+
+	it('custom handler all', async () => {
+		const app = new SmartApp()
+			.appId('xxx')
+			.firstPageId('page1')
+			.permissions(['r:devices:*'])
+			.disableCustomDisplayName(true)
+			.disableRemoveApp(true)
+			.initialized((ctx, initialization) => {
+				initialization.firstPageId('page2')
+					.disableCustomDisplayName(false)
+					.disableRemoveApp(false)
+					.permissions(['r:devices:*', 'x:devices:*'])
+			})
+
+		// Initialize configuration callback
+		const resp = await app.handleMockCallback({
+			lifecycle: 'CONFIGURATION',
+			executionId: 'e6903fe6-f88f-da69-4c12-e2802606ccbc',
+			locale: 'en',
+			version: '0.1.0',
+			client: {
+				os: 'ios',
+				version: '0.0.0',
+				language: 'en-US'
+			},
+			configurationData: {
+				installedAppId: '7d7fa36d-0ad9-4893-985c-6b75858e38e4',
+				phase: 'INITIALIZE',
+				pageId: '',
+				previousPageId: '',
+				config: {}
+			},
+			settings: {}
+		})
+
+		const expectedInitResponse = {initialize: {
+			id: 'xxx',
+			firstPageId: 'page2',
+			permissions: ['r:devices:*', 'x:devices:*'],
+			disableCustomDisplayName: false,
+			disableRemoveApp: false
+		}}
+
+		assert.deepStrictEqual(resp.configurationData, expectedInitResponse)
+	})
+})


### PR DESCRIPTION
Added optional handler for CONFIGURATION/INITIALIZE event so that values such as firstPage and permissions can be dynamically set. Addresses issue #176 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
