### PR TITLE
fix: support other API urls for API_ONLY apps

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -432,7 +432,13 @@ class SmartApp {
 	}
 
 	async handleOAuthCallback(request) {
-		const oauthClient = new SmartThingsOAuthClient(this._clientId, this._clientSecret, this._redirectUri)
+		const oauthClient = this._apiUrl && this._refreshUrl ?
+			new SmartThingsOAuthClient(this._clientId, this._clientSecret, this._redirectUri,
+				{
+					baseURL: this._apiUrl,
+					authURL: this._refreshUrl,
+					keyApiURL: this._authorizer._keyResolver._httpKeyResolve._keyApiHost}) :
+			new SmartThingsOAuthClient(this._clientId, this._clientSecret, this._redirectUri)
 		const auth = await oauthClient.redeemCode(request.query.code)
 		const ctx = await this.withContext({
 			installedAppId: auth.installed_app_id,


### PR DESCRIPTION
Properly set the URL provider for handling OAuth requests so that the SDK can support other ST environments with different API URLs

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
