### PR TITLE
feat: added default scheduled event handler

### DIFF
--- a/docs/classes/_smart_app_d_.smartapp.md
+++ b/docs/classes/_smart_app_d_.smartapp.md
@@ -44,6 +44,7 @@ Name | Type | Description |
 * [contextStore](_smart_app_d_.smartapp.md#contextstore)
 * [defaultDeviceCommandHandler](_smart_app_d_.smartapp.md#defaultdevicecommandhandler)
 * [defaultPage](_smart_app_d_.smartapp.md#defaultpage)
+* [defaultScheduledEventHandler](_smart_app_d_.smartapp.md#defaultscheduledeventhandler)
 * [deviceCommand](_smart_app_d_.smartapp.md#devicecommand)
 * [deviceCommandHandler](_smart_app_d_.smartapp.md#devicecommandhandler)
 * [disableCustomDisplayName](_smart_app_d_.smartapp.md#disablecustomdisplayname)
@@ -260,6 +261,31 @@ Name | Type |
 `configData?` | InstalledAppConfiguration |
 
 **Returns:** *[SmartApp](_smart_app_d_.smartapp.md)*
+
+___
+
+###  defaultScheduledEventHandler
+
+▸ **defaultScheduledEventHandler**(`callback`: function): *[SmartApp](_smart_app_d_.smartapp.md)*
+
+Defines a handler to be called for any scheduled event that does not have a handler
+defined for that specific event. 
+
+**Parameters:**
+
+▪ **callback**: *function*
+
+▸ (`context`: [SmartAppContext](../interfaces/_util_smart_app_context_d_.smartappcontext.md), `eventData`: TimerEvent): *[HandlerResponse](../modules/_smart_app_d_.md#handlerresponse)*
+
+**Parameters:**
+
+Name | Type                                                                           |
+------ |--------------------------------------------------------------------------------|
+`context` | [SmartAppContext](../interfaces/_util_smart_app_context_d_.smartappcontext.md) |                                                                        |
+`eventData` | TimerEvent                                                                     |
+
+**Returns:** *[SmartApp](_smart_app_d_.smartapp.md)*
+
 
 ___
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,7 @@ const smartapp = new SmartApp()
     })
 ```
 * [defaultDeviceCommandHandler](classes/_smart_app_d_.smartapp.md#defaultdevicecommandhandler)
+* [defaultScheduledEventHandler](classes/_smart_app_d_.smartapp.md#defaultscheduledeventhandler)
 * [deviceCommand](classes/_smart_app_d_.smartapp.md#devicecommand)
 * [deviceCommandHandler](classes/_smart_app_d_.smartapp.md#devicecommandhandler)
 * [oauthHandler](classes/_smart_app_d_.smartapp.md#oauthhandler)

--- a/lib/smart-app.d.ts
+++ b/lib/smart-app.d.ts
@@ -454,7 +454,7 @@ export class SmartApp {
 	refreshUrl(url: string): SmartApp
 
 	/**
-	* Defines a handler for scheduled events. The name corresponds the the name specified when the event is
+	* Defines a handler for scheduled events. The name corresponds to the name specified when the event is
 	* scheduled by the `context.api.schedules.create()` call or any of its other variants. There can be
 	* multiple scheduled event handlers in one app.
 	* @param name the name used when the event to be handled was scheduled
@@ -466,6 +466,17 @@ export class SmartApp {
 			context: SmartAppContext,
 			eventData: TimerEvent,
 			eventTime?: string) => HandlerResponse): SmartApp
+
+	/**
+	 * Defines a default handler for scheduled events that is called if a matching named handler is not found.
+	 * @param callback the handler to be called with the event
+	 */
+	defaultScheduledEventHandler(
+		callback: (
+			context: SmartAppContext,
+			eventData: TimerEvent,
+			eventTime?: string
+		) => HandlerResponse): SmartApp
 
 	/**
 	* Defines a handler for device event subscriptions. Device events occur whenever one

--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -25,6 +25,7 @@ class SmartApp {
 		this._subscribedEventHandlers = {}
 		this._eventTypeHandlers = {}
 		this._scheduledEventHandlers = {}
+		this._defaultScheduledEventHandler = null
 		this._pages = {}
 		this._defaultPage = ((ctx, page, configurationData) => {
 			page.name('System Error!')
@@ -303,6 +304,17 @@ class SmartApp {
 	 */
 	scheduledEventHandler(name, callback) {
 		this._scheduledEventHandlers[name] = callback
+		return this
+	}
+
+	/**
+	 * Handler for scheduled events that don't have individual handlers
+	 *
+	 * @param {Object} callback Callback handler object
+	 * @returns {SmartApp} SmartApp instance
+	 */
+	defaultScheduledEventHandler(callback) {
+		this._defaultScheduledEventHandler = callback
 		return this
 	}
 
@@ -632,6 +644,9 @@ class SmartApp {
 								const handler = this._scheduledEventHandlers[handlerName]
 								if (handler) {
 									results.push(handler(context, event.timerEvent, event.eventTime))
+									break
+								} else if (this._defaultScheduledEventHandler) {
+									results.push(this._defaultScheduledEventHandler(context, event.timerEvent, event.eventTime))
 									break
 								} else {
 									this._log.error(`Timer event handler '${handlerName}' not defined`)


### PR DESCRIPTION
Added a default handler for scheduled events that will be called whenever there isn't a matching handler for the schedule name. This feature is useful for cases where the name is used to convey information, such as the ID of an entity.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] Any required documentation has been added
- [ ] I have added tests to cover my changes
