### PR TITLE
feat: added i18n translation to postMessage fields

### DIFF
--- a/docs/classes/_pages_decimal_setting_d_.decimalsetting.md
+++ b/docs/classes/_pages_decimal_setting_d_.decimalsetting.md
@@ -153,7 +153,9 @@ ___
 ▸ **postMessage**(`value`: string): *[DecimalSetting](_pages_decimal_setting_d_.decimalsetting.md)*
 
 A string to be shown after the text input field. One common use for this field is to
-specify a unit of measure.
+specify a unit of measure. Omitting the value and calling `postMessage()` will set the
+value to the default i18n string, allowing translations to be defines in the locale
+file in the usual way.
 
 **Parameters:**
 

--- a/docs/classes/_pages_number_setting_d_.numbersetting.md
+++ b/docs/classes/_pages_number_setting_d_.numbersetting.md
@@ -161,7 +161,9 @@ ___
 ▸ **postMessage**(`value`: string): *[NumberSetting](_pages_number_setting_d_.numbersetting.md)*
 
 A string to be shown after the text input field. One common use for this field is to
-specify a unit of measure.
+specify a unit of measure. Omitting the value and calling `postMessage()` will set the
+value to the default i18n string, allowing translations to be defines in the locale
+file in the usual way.
 
 **Parameters:**
 
@@ -195,7 +197,7 @@ ___
 
 ▸ **step**(`value`: number): *[NumberSetting](_pages_number_setting_d_.numbersetting.md)*
 
-The step between values values. If the style is not set to slider then setting a step will
+The step between values. If the style is not set to slider then setting a step will
 cause up and down arrows to appear next to the input box that increment or decrement the value
 by the value of the step.
 

--- a/lib/pages/decimal-setting.d.ts
+++ b/lib/pages/decimal-setting.d.ts
@@ -32,8 +32,10 @@ export class DecimalSetting extends SectionSetting<DecimalSetting> {
 
 	/**
 	* A string to be shown after the text input field. One common use for this field is to
-	* specify a unit of measure.
+	* specify a unit of measure. Omitting the value and calling `postMessage()` will set the
+	* value to the default i18n string, allowing translations to be defines in the locale
+	* file in the usual way.
 	* @param value Max length 10 characters
 	*/
-	postMessage(value: string): DecimalSetting
+	postMessage(value?: string): DecimalSetting
 }

--- a/lib/pages/decimal-setting.js
+++ b/lib/pages/decimal-setting.js
@@ -7,7 +7,6 @@ module.exports = class DecimalSetting extends SectionSetting {
 		super(section, id)
 		this._type = 'DECIMAL'
 		this._description = 'Tap to set'
-		this._postMessage = this.i18nKey('postMessage')
 	}
 
 	max(value) {
@@ -26,7 +25,12 @@ module.exports = class DecimalSetting extends SectionSetting {
 	}
 
 	postMessage(value) {
-		this._postMessage = value
+		if (value === undefined) {
+			this._postMessage = this.i18nKey('postMessage')
+		} else {
+			this._postMessage = value
+		}
+
 		return this
 	}
 
@@ -45,7 +49,7 @@ module.exports = class DecimalSetting extends SectionSetting {
 		}
 
 		if (this._postMessage) {
-			result.postMessage = this._postMessage
+			result.postMessage = this.translate(this._postMessage)
 		}
 
 		return result

--- a/lib/pages/number-setting.d.ts
+++ b/lib/pages/number-setting.d.ts
@@ -42,13 +42,15 @@ export class NumberSetting extends SectionSetting<NumberSetting> {
 
 	/**
 	* A string to be shown after the text input field. One common use for this field is to
-	* specify a unit of measure.
+	* specify a unit of measure. Omitting the value and calling `postMessage()` will set the
+	* value to the default i18n string, allowing translations to be defines in the locale
+	* file in the usual way.
 	* @param value Max length 10 characters
 	*/
-	postMessage(value: string): NumberSetting
+	postMessage(value?: string): NumberSetting
 
 	/**
-	* The step between values values. If the style is not set to slider then setting a step will
+	* The step between values. If the style is not set to slider then setting a step will
 	* cause up and down arrows to appear next to the input box that increment or decrement the value
 	* by the value of the step.
 	*/

--- a/lib/pages/number-setting.js
+++ b/lib/pages/number-setting.js
@@ -73,7 +73,12 @@ module.exports = class NumberSetting extends SectionSetting {
 	 * @returns {NumberSetting} Number Setting instance
 	 */
 	postMessage(value) {
-		this._postMessage = value
+		if (value === undefined) {
+			this._postMessage = this.i18nKey('postMessage')
+		} else {
+			this._postMessage = value
+		}
+
 		return this
 	}
 
@@ -100,7 +105,7 @@ module.exports = class NumberSetting extends SectionSetting {
 		}
 
 		if (this._postMessage) {
-			result.postMessage = this._postMessage
+			result.postMessage = this.translate(this._postMessage)
 		}
 
 		return result


### PR DESCRIPTION
Updated the decimal and number settings to support translations of the `postMessage` field via locale files. Previously translation was not supported. Only literal values could be set with `postMessage`.

Also fixed a bug in the decimal setting where the i18n key was displayed but not translated,  if `postMessage` was not set.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [x] Any required documentation has been added
- [ ] I have added tests to cover my changes
