### PR TITLE
fix: bug where context state was overwritten at install

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -593,14 +593,21 @@ class SmartApp {
 					this._log.event(evt)
 					await this._installedHandler(context, evt.installData)
 					if (this._contextStore) {
-						await this._contextStore.put({
+						const contextRecord = {
 							installedAppId: context.installedAppId,
 							locationId: context.locationId,
 							authToken: context.authToken,
 							refreshToken: context.refreshToken,
 							config: context.config,
 							locale: context.locale,
-						})
+						}
+
+						const storedContext = await this._contextStore.get(context.installedAppId)
+						if (storedContext) {
+							await this._contextStore.update(context.installedAppId, contextRecord)
+						} else {
+							await this._contextStore.put(contextRecord)
+						}
 					}
 
 					responder.respond({statusCode: 200, installData: {}})


### PR DESCRIPTION
Fixed a bug where the INSTALLED lifecycle event was overwriting any state items stored in the installed app context during the initial page flow.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
