### PR TITLE
fix: Async issues with handleHttpCallbackUnverified

### DIFF
--- a/lib/smart-app.js
+++ b/lib/smart-app.js
@@ -428,8 +428,8 @@ class SmartApp {
 	 * @param {*} request
 	 * @param {*} response
 	 */
-	handleHttpCallbackUnverified(request, response) {
-		this._handleCallback(request.body, responders.httpResponder(response, this._log))
+	async handleHttpCallbackUnverified(request, response) {
+		return this._handleCallback(request.body, responders.httpResponder(response, this._log))
 	}
 
 	/**


### PR DESCRIPTION
Hello,

Issues arise with testing SmartApp locally, due to handleHttpCallbackUnverified not being an async method.

As with other methods, and following the documentation, handleHttpCallbackUnverified now returns a Promise and can be properly awaited.

<!-- Describe your pull request. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [X] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
