### PR TITLE
fix: Type issue for non-default DeviceCommandHandlers

### DIFF
--- a/lib/smart-app.d.ts
+++ b/lib/smart-app.d.ts
@@ -3,7 +3,7 @@ import { IncomingHttpHeaders } from 'http'
 import { i18n } from './i18n'
 import ConfigurationOptions = i18n.ConfigurationOptions
 import { Logger } from './util/log'
-import { DeviceCommand, InstalledAppConfiguration } from '@smartthings/core-sdk'
+import { InstalledAppConfiguration } from '@smartthings/core-sdk'
 import { Page } from './pages/page'
 import { SmartAppContext } from './util/smart-app-context'
 import { AppEvent } from './lifecycle-events'
@@ -15,6 +15,7 @@ import ModeEvent = AppEvent.ModeEvent
 import SceneLifecycleEvent = AppEvent.SceneLifecycleEvent
 import TimerEvent = AppEvent.TimerEvent
 import DeviceCommandsEvent = AppEvent.DeviceCommandsEvent
+import DeviceCommandsEventCommand = AppEvent.DeviceCommandsEventCommand
 import SecurityArmStateEvent = AppEvent.SecurityArmStateEvent
 import ExecuteData = AppEvent.ExecuteData
 import UninstallData = AppEvent.UninstallData
@@ -288,7 +289,7 @@ export class SmartApp {
 		callback: (
 			context: SmartAppContext,
 			deviceId: string,
-			cmd: DeviceCommand) => HandlerResponse): SmartApp
+			cmd: DeviceCommandsEventCommand) => HandlerResponse): SmartApp
 
 	/**
 	* Defines a handler that is called for any configuration page that does not have a specific page handler
@@ -310,7 +311,7 @@ export class SmartApp {
 	deviceCommand(command: string, callback: (
 		context: SmartAppContext,
 		deviceId: string,
-		cmd: DeviceCommand,
+		cmd: DeviceCommandsEventCommand,
 		eventTime?: string) => HandlerResponse): SmartApp
 
 	/**


### PR DESCRIPTION
<!-- Describe your pull request. -->
There is a type issue with `deviceCommand()` callback's type, impacting the usage of `smartApp.deviceCommand()` in TypeScript. 

`deviceCommand()` defines a callback with a `command` parameter of type `DeviceCommand`. This is incorrect, as `DeviceCommand` has a `component` attribute, instead of `componentId` attribute as obtained from the APIs.

Default `deviceCommandHandler()` is not impacted, as it uses the interface `DeviceCommandsEvent`, itself using the correct type `DeviceCommandsEventCommand`.

This is becoming a mouthful. Here are the current classes :

Incorrect for `deviceCommand()`
https://github.com/SmartThingsCommunity/smartthings-core-sdk/blob/bdd6bcc59044daef46725524e7fb3234d4cc0c1a/src/endpoint/rules.ts#L185-L191

Correct for `deviceCommand()`
https://github.com/SmartThingsCommunity/smartapp-sdk-nodejs/blob/3725c0f5c6ff1f82a8219ba5399019e707526b49/lib/lifecycle-events.d.ts#L192-L197


Note that this PR is marked as incomplete, as this `DeviceCommandsEventCommand` is difficult to import for external projects. I would leave that decision to you in order to export or create an interface.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (hint: install an [xo editor plugin](https://github.com/xojs/xo#editor-plugins))
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
